### PR TITLE
Reduce Noise Filtering

### DIFF
--- a/src/color_segmenter.cpp
+++ b/src/color_segmenter.cpp
@@ -41,7 +41,7 @@ void ColorSegmenter::xgboost_mask()
     };
 
     // structuring element for denoising
-    constexpr unsigned OPEN_RADIUS = 2;
+    constexpr unsigned OPEN_RADIUS = 1;
     static const cv::Mat open_kernel = cv::getStructuringElement(
         cv::MORPH_ELLIPSE, cv::Size(2 * OPEN_RADIUS + 1, 2 * OPEN_RADIUS + 1));
 
@@ -87,7 +87,6 @@ void ColorSegmenter::xgboost_mask()
     // post-process masks
     for (FaceColor color : cube_model_.get_colors())
     {
-        // todo: would be good to add this back
         // "open" image to get rid of single-pixel noise
         cv::morphologyEx(
             masks_[color], masks_[color], cv::MORPH_OPEN, open_kernel);

--- a/src/single_observation.cpp
+++ b/src/single_observation.cpp
@@ -81,10 +81,12 @@ int main(int argc, char **argv)
     }
     else
     {
-        cv::imwrite(debug_out_dir +
-                        data_dir.substr(data_dir.find_last_of("/\\") + 1, 4) +
-                        "__" + std::string(buffer) + ".jpg",
-                    debug_img);
+        std::string out_file =
+            debug_out_dir + "/" +
+            data_dir.substr(data_dir.find_last_of("/\\") + 1, 4) + "__" +
+            std::string(buffer) + ".jpg";
+        std::cout << "Write to " << out_file << std::endl;
+        cv::imwrite(out_file, debug_img);
     }
 #endif
 


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

* Reduce the kernel radius for noise removal in the segmentation masks to prevent good pixels from being discarded while still getting rid of most of the actual noise.
* Minor fix in single_observation: Do not depend on output path for images containing a trailing `/`.


## How I Tested

One example where there is a notable improvement:

OPEN_RADIUS = 2 (old value):
![0021__1605019544](https://user-images.githubusercontent.com/9333121/98690360-24c17e00-236d-11eb-8530-8938bfa866ea.jpg)

OPEN_RADIUS = 1 (new value):
![0021__1605019619](https://user-images.githubusercontent.com/9333121/98690366-25f2ab00-236d-11eb-96b5-ad4fb850d07f.jpg)

I also tested with removing the filter completely but this resulted in significantly worse poses.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [ ] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [ ] All new functions/classes are documented and existing documentation is updated according to changes.
- [ ] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
