### PR TITLE
fix: set num_misclassified_pixels_ again

### DIFF
--- a/src/pose_detector.cpp
+++ b/src/pose_detector.cpp
@@ -389,6 +389,8 @@ float PoseDetector::compute_confidence(
     float confidence = 0.4 * good_pixel_ratio + 0.3 * filled_face_ratio +
                        0.3 * cameras_with_pixels_ratio;
 
+    num_misclassified_pixels_ = num_misclassified_pixels;
+
     return confidence;
 }
 


### PR DESCRIPTION
## Description

Set num_misclassified_pixels_ again.  Without this, `get_num_misclasssifed_pixels()` does not report the correct
value (used for the debug visualisation).

Note that this is only used in the debug visualisation, so the bug did not affect the actual tracking.

## How I Tested

By running it on images, checking the value printed in the debug image.