### PR TITLE
Use pybind11_opencv for direct cv::Mat <-> np.array

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,10 +25,10 @@ string(APPEND CMAKE_CXX_FLAGS " -O3")
 #  - 4: CUBOID_2x2x8
 set(OBJECT_VERSION 4)
 
-
 find_package(ament_cmake REQUIRED)
 find_package(mpi_cmake_modules REQUIRED)
 find_package(pybind11 REQUIRED)
+find_package(pybind11_opencv REQUIRED)
 find_package(serialization_utils REQUIRED)
 find_package(time_series REQUIRED)
 find_package(trifinger_cameras REQUIRED)
@@ -193,6 +193,7 @@ target_include_directories(pybullet_tricamera_object_tracker_driver PUBLIC
 )
 target_link_libraries(pybullet_tricamera_object_tracker_driver
     pybind11::pybind11
+    pybind11_opencv::pybind11_opencv
     robot_interfaces::robot_interfaces
     serialization_utils::serialization_utils
     cube_detector
@@ -208,6 +209,7 @@ add_pybind11_module(py_object_tracker srcpy/py_object_tracker.cpp
 )
 add_pybind11_module(py_tricamera_types srcpy/py_tricamera_types.cpp
     LINK_LIBRARIES
+        pybind11_opencv::pybind11_opencv
         ${tricamera_object_tracking_driver}
         pybullet_tricamera_object_tracker_driver
         cube_visualizer

--- a/include/trifinger_object_tracking/pybullet_tricamera_object_tracker_driver.hpp
+++ b/include/trifinger_object_tracking/pybullet_tricamera_object_tracker_driver.hpp
@@ -58,12 +58,8 @@ public:
         if (render_images)
         {
             // some imports that are needed later for converting images (numpy
-            // array
-            // -> cv::Mat)
+            // array -> cv::Mat)
             numpy_ = pybind11::module::import("numpy");
-            pybind11::module camera_types =
-                pybind11::module::import("trifinger_cameras.py_camera_types");
-            cvMat_ = camera_types.attr("cvMat");
 
             // TriFingerCameras gives access to the cameras in simulation
             pybind11::module mod_camera =
@@ -89,8 +85,6 @@ private:
 
     //! @brief The numpy module.
     pybind11::module numpy_;
-    //! @brief Python class that wraps cv::Mat (used for conversion).
-    pybind11::object cvMat_;
 
     time_series::Index last_update_robot_time_index_;
 };

--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,7 @@
   <build_depend>mpi_cmake_modules</build_depend>
   <build_depend>pybind11_vendor</build_depend>
   <build_depend>pybind11</build_depend>
+  <build_depend>pybind11_opencv</build_depend>
 
   <depend>ament_index_cpp</depend>
   <depend>serialization_utils</depend>

--- a/scripts/tricamera_log_viewer.py
+++ b/scripts/tricamera_log_viewer.py
@@ -160,14 +160,10 @@ def main():
             object_pose.position = object_pose.position + cube_rot.apply(offset)
 
         if args.visualize_goal_pose:
-            cvmats = [trifinger_cameras.camera.cvMat(img) for img in images]
-            images = cube_visualizer.draw_cube(cvmats, goal_pose, True)
-            images = [np.array(img) for img in images]
+            images = cube_visualizer.draw_cube(images, goal_pose, True)
 
         if args.visualize_object_pose:
-            cvmats = [trifinger_cameras.camera.cvMat(img) for img in images]
-            images = cube_visualizer.draw_cube(cvmats, object_pose, False)
-            images = [np.array(img) for img in images]
+            images = cube_visualizer.draw_cube(images, object_pose, False)
 
         if args.show_confidence:
             images = [cv2.putText(

--- a/src/pybullet_tricamera_object_tracker_driver.cpp
+++ b/src/pybullet_tricamera_object_tracker_driver.cpp
@@ -11,6 +11,8 @@
 
 #include <pybind11/eigen.h>
 #include <pybind11/embed.h>
+
+#include <pybind11_opencv/cvbind.hpp>
 #include <serialization_utils/cereal_cvmat.hpp>
 
 namespace py = pybind11;
@@ -71,8 +73,6 @@ PyBulletTriCameraObjectTrackerDriver::get_observation()
                 // ensure that the image array is contiguous in memory,
                 // otherwise conversion to cv::Mat would fail
                 auto image = numpy_.attr("ascontiguousarray")(images[i]);
-                // convert to cv::Mat
-                image = cvMat_(image);
                 observation.cameras[i].image = image.cast<cv::Mat>();
             }
         }

--- a/srcpy/py_tricamera_types.cpp
+++ b/srcpy/py_tricamera_types.cpp
@@ -10,6 +10,8 @@
 #include <pybind11/stl_bind.h>
 #include <pybind11/stl.h>
 
+#include <pybind11_opencv/cvbind.hpp>
+
 #include <trifinger_object_tracking/pybullet_tricamera_object_tracker_driver.hpp>
 #ifdef Pylon_FOUND
 #include <trifinger_object_tracking/tricamera_object_tracking_driver.hpp>


### PR DESCRIPTION
## Description

Equivalent to https://github.com/open-dynamic-robot-initiative/trifinger_cameras/pull/15.

Further, tricamera_log_viewer.py can be simplified as `cv::Mat` is directly bound to `np.array`.

## How I Tested

- By running the pybullet backend (which uses the PyBulletTriCameraObjectTrackerDriver when run with `--add-cube`) and visualising the images with demo_cameras.py.
- By running `tricamera_log_viewer.py` with all visualisations enabled.


## Do not merge before

- [x] https://github.com/open-dynamic-robot-initiative/pybind11_opencv/pull/1
- [x] https://github.com/open-dynamic-robot-initiative/trifinger_cameras/pull/15
- [x] `pybind11_opencv` is added to the treep config.

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
