### PR TITLE
Suppress warnings of optim

### DIFF
--- a/include/trifinger_object_tracking/pose_detector.hpp
+++ b/include/trifinger_object_tracking/pose_detector.hpp
@@ -6,9 +6,16 @@
 #include <trifinger_object_tracking/cube_model.hpp>
 #include <trifinger_object_tracking/types.hpp>
 
+// ignore all warnings of optim (this is a third-party library)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+
 #define OPTIM_ENABLE_ARMA_WRAPPERS
 #define OPTIM_DONT_USE_OPENMP
 #include <optim/optim.hpp>
+
+#pragma GCC diagnostic pop
+
 
 namespace trifinger_object_tracking
 {


### PR DESCRIPTION


[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Suppress the "unused-parameter" warnings of optim to not clutter the warning output of our own code.


## How I Tested

Clean rebuild of the workspace.



## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
