### PR TITLE
Use cv::videoWriter::fourcc instead of CV_FOURCC

### DIFF
--- a/src/run_on_logfile.cpp
+++ b/src/run_on_logfile.cpp
@@ -10,15 +10,12 @@
  * - camera300.yml: Calibration parameters of camera300
  */
 #include <iostream>
-#include <string>
-
 #include <opencv2/opencv.hpp>
-
 #include <robot_interfaces/sensors/sensor_log_reader.hpp>
+#include <string>
 // TODO: not sure why but if "sensor_logger.hpp" is not included, the log reader
 // will have a cereal-related build error.
 #include <robot_interfaces/sensors/sensor_logger.hpp>
-
 #include <trifinger_object_tracking/cube_detector.hpp>
 #include <trifinger_object_tracking/tricamera_object_observation.hpp>
 #include <trifinger_object_tracking/utils.hpp>
@@ -93,11 +90,12 @@ int main(int argc, char **argv)
             if (!debug_video_file.empty())
             {
                 constexpr double FPS = 10.0;
-                bool ok = open_video_writer(debug_video,
-                                            debug_video_file,
-                                            CV_FOURCC('X', 'V', 'I', 'D'),
-                                            FPS,
-                                            debug_img.size());
+                bool ok = open_video_writer(
+                    debug_video,
+                    debug_video_file,
+                    cv::VideoWriter::fourcc('X', 'V', 'I', 'D'),
+                    FPS,
+                    debug_img.size());
                 if (!ok)
                 {
                     return 1;


### PR DESCRIPTION
This makes the code compatible with newer versions of OpenCV.

[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Use cv::videoWriter::fourcc instead of CV_FOURCC.  This makes the code compatible with newer versions of OpenCV.



## How I Tested

By running `run_on_logfile` and verifying the resulting video.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
