### PR TITLE
Fix strftime format warning

### DIFF
--- a/src/single_observation.cpp
+++ b/src/single_observation.cpp
@@ -66,11 +66,6 @@ int main(int argc, char **argv)
 #ifdef VISUALIZE
     cv::Mat debug_img = cube_detector.create_debug_image(false);
 
-    time_t t = time(0);  // get time now
-    struct tm *now = localtime(&t);
-    char buffer[80];
-    strftime(buffer, 80, "%s", now);
-
     if (debug_out_dir.empty())
     {
         cv::namedWindow("debug", cv::WINDOW_NORMAL);
@@ -80,10 +75,11 @@ int main(int argc, char **argv)
     }
     else
     {
+        time_t now = time(0);  // get time now
         std::string out_file =
             debug_out_dir + "/" +
             data_dir.substr(data_dir.find_last_of("/\\") + 1, 4) + "__" +
-            std::string(buffer) + ".jpg";
+            std::to_string(now) + ".jpg";
         std::cout << "Write to " << out_file << std::endl;
         cv::imwrite(out_file, debug_img);
     }


### PR DESCRIPTION
## Description

The "%s" format in `strftime` is not officially supported by the C++
standard.  To get rid of the corresponding warning, simple convert the
`time_t` to string directly, using `std::to_string`.
This might behave differently on non-unix systems but that shouldn't be
a problem here.

## How I Tested

By running it and checking the resulting filename.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
