### PR TITLE
Add cuboid-specific cost terms only for the actual cuboid

### DIFF
--- a/demos/run_on_logfile.py
+++ b/demos/run_on_logfile.py
@@ -28,7 +28,7 @@ def main():
     camera_log_file = args.log_dir / "camera_data.dat"
 
     if not args.log_dir.is_dir():
-        print("{} does not exist.".format(args.log_dir))
+        print("{} is not a directory.".format(args.log_dir))
         sys.exit(1)
 
     calib_files = []

--- a/src/pose_detector.cpp
+++ b/src/pose_detector.cpp
@@ -223,15 +223,16 @@ float PoseDetector::cost_function(
                     }
                     else
                     {
+#if OBJECT_VERSION == CUBOID_2x2x8
                         // we would like the borders to be close to some
                         // pixels. under the assumption that some parts of the
                         // object boundaries are visible this should help
                         // resolve ambiguities
                         distance_cost += 0.05 * pow(dist, 0.5);
+#endif
                     }
                 }
                 distance_cost *= distance_cost_scaling;
-                // std::cout << "cost (visible): " << cost << std::endl;
             }
 
             float invisibility_cost = 0.;
@@ -254,9 +255,11 @@ float PoseDetector::cost_function(
         }
     }
 
+#if OBJECT_VERSION == CUBOID_2x2x8
     // simple height cost (assume that it is more likely that the object is
     // further down
     cost += position[2] * height_cost_scaling;
+#endif
 
     return cost;
 }


### PR DESCRIPTION
## Description

Add cuboid-specific cost terms only for the actual cuboid.  This should restore the original behaviour for the cube.


## How I Tested

Running the tracker on a logfile.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
