### PR TITLE
Single colour segmentation for 'lightblue' dice

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED on)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # stop build on first error
-string(APPEND CMAKE_CXX_FLAGS " -Wall -Wextra -Wfatal-errors")
+string(APPEND CMAKE_CXX_FLAGS " -Wall -Wextra -Wfatal-errors -Werror=return-type")
 
 # always enable optimization, otherwise object tracking is too slow
 string(APPEND CMAKE_CXX_FLAGS " -O3")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,28 +109,6 @@ target_link_libraries(cube_visualizer
 )
 
 
-add_executable(single_observation src/single_observation.cpp)
-target_include_directories(single_observation PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
-)
-target_link_libraries(single_observation
-    cube_detector
-)
-
-
-add_executable(run_on_logfile src/run_on_logfile.cpp)
-target_include_directories(run_on_logfile PRIVATE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
-    ${OpenCV_INCLUDE_DIRS}
-)
-target_link_libraries(run_on_logfile
-    robot_interfaces::robot_interfaces
-    cube_detector
-)
-
-
 # TODO frontend should be in separate library
 
 add_library(simulation_object_tracker
@@ -203,6 +181,19 @@ set_target_properties(pybullet_tricamera_object_tracker_driver
     PROPERTIES CXX_VISIBILITY_PRESET hidden)
 
 
+add_library(lightblue_segmenter
+    src/xgb_single_color/lightblue_rgb.cpp
+    src/xgb_single_color/segment_image.cpp
+)
+target_include_directories(lightblue_segmenter PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+target_link_libraries(lightblue_segmenter
+    ${OpenCV_LIBS}
+)
+
+
 # Python Bindings
 add_pybind11_module(py_object_tracker srcpy/py_object_tracker.cpp
     LINK_LIBRARIES
@@ -218,6 +209,43 @@ add_pybind11_module(py_tricamera_types srcpy/py_tricamera_types.cpp
         ${tricamera_object_tracking_driver}
         pybullet_tricamera_object_tracker_driver
         cube_visualizer
+)
+add_pybind11_module(py_lightblue_segmenter srcpy/py_lightblue_segmenter.cpp
+    LINK_LIBRARIES
+        pybind11_opencv::pybind11_opencv
+        lightblue_segmenter
+)
+
+
+add_executable(single_observation src/single_observation.cpp)
+target_include_directories(single_observation PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+target_link_libraries(single_observation
+    cube_detector
+)
+
+
+add_executable(run_on_logfile src/run_on_logfile.cpp)
+target_include_directories(run_on_logfile PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+    ${OpenCV_INCLUDE_DIRS}
+)
+target_link_libraries(run_on_logfile
+    robot_interfaces::robot_interfaces
+    cube_detector
+)
+
+
+add_executable(demo_lightblue_segmenter_cpp demos/demo_lightblue_segmenter.cpp)
+target_include_directories(demo_lightblue_segmenter_cpp PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+target_link_libraries(demo_lightblue_segmenter_cpp
+    lightblue_segmenter
 )
 
 
@@ -240,6 +268,7 @@ install(
         pybullet_tricamera_object_tracker_driver
         single_observation
         run_on_logfile
+        demo_lightblue_segmenter_cpp
 
     EXPORT export_${PROJECT_NAME}
     ARCHIVE DESTINATION lib
@@ -269,6 +298,7 @@ install_scripts(
 install(
     PROGRAMS
         demos/demo_cameras.py
+        demos/demo_lightblue_segmenter.py
         demos/run_on_logfile.py
 
     DESTINATION lib/${PROJECT_NAME}

--- a/demos/demo_lightblue_segmenter.cpp
+++ b/demos/demo_lightblue_segmenter.cpp
@@ -1,0 +1,32 @@
+#include <iostream>
+#include <string>
+#include <opencv2/opencv.hpp>
+#include <trifinger_object_tracking/xgboost_classifier_single_color_rgb.h>
+
+int main(int argc, char *argv[])
+{
+    if (argc != 2)
+    {
+        std::cout << "Wrong number of arguments. " << argc << std::endl;
+        std::cout << "Usage: " << argv[0] << " path/to/image" << std::endl;
+        return 1;
+    }
+
+    std::string image_path(argv[1]);
+    std::cout << "load image " << image_path << std::endl;
+
+    cv::Mat img = cv::imread(image_path);
+    cv::Mat mask = trifinger_object_tracking::segment_image(img);
+
+    // apply the mask on the image to get the segmented areas
+    cv::Mat segmented;
+    img.copyTo(segmented, mask);
+
+    // concat images for nicer visualisation
+    cv::Mat merged;
+    cv::hconcat(img, segmented, merged);
+    cv::imshow("Lightblue Segmenter", merged);
+    cv::waitKey(0);
+
+    return 0;
+}

--- a/demos/demo_lightblue_segmenter.py
+++ b/demos/demo_lightblue_segmenter.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Run the 'lightblue' segmenter on single images"""
+import argparse
+import sys
+
+import cv2
+import numpy as np
+from trifinger_object_tracking.py_lightblue_segmenter import segment_image
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input_image")
+    args = parser.parse_args()
+
+    # load the image
+    img = cv2.imread(args.input_image)
+
+    # get the segmentation mask
+    mask = segment_image(img)
+
+    # for nicer visualisation get the masked area from the original image
+    segmented = cv2.bitwise_and(img, img, mask=mask)
+
+    # stack together for visualisation
+    both = np.hstack([img, segmented])
+    cv2.imshow("Lightblue Segmenter", both)
+    cv2.waitKey()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/include/trifinger_object_tracking/xgboost_classifier_single_color_rgb.h
+++ b/include/trifinger_object_tracking/xgboost_classifier_single_color_rgb.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <array>
+#include <opencv2/opencv.hpp>
+
+namespace trifinger_object_tracking
+{
+constexpr int XGB_NUM_CLASSES = 1;
+constexpr int XGB_NUM_FEATURES = 3;
+
+std::array<float, XGB_NUM_CLASSES> xgb_classify(
+    const std::array<float, XGB_NUM_FEATURES> &sample);
+
+/**
+ * @brief Segment image using a binary pixel classifier
+ *
+ * @param image_bgr  The image in BGR format.
+ *
+ * @return Single-channel segmentation mask.
+ */
+cv::Mat segment_image(const cv::Mat &image_bgr);
+
+}  // namespace trifinger_object_tracking

--- a/src/xgb_single_color/lightblue_rgb.cpp
+++ b/src/xgb_single_color/lightblue_rgb.cpp
@@ -1,0 +1,100 @@
+#include <trifinger_object_tracking/xgboost_classifier_single_color_rgb.h>
+
+namespace trifinger_object_tracking
+{
+std::array<float, XGB_NUM_CLASSES> xgb_classify(
+    const std::array<float, XGB_NUM_FEATURES> &sample)
+{
+    std::array<float, XGB_NUM_CLASSES> sum;
+    sum.fill(0.0);
+
+    if (sample[2] < 23.5)
+    {
+        if (sample[0] < 52)
+        {
+            sum[0] += -1.99386501;
+        }
+        else
+        {
+            if (sample[0] < 63.5)
+            {
+                sum[0] += 0.5;
+            }
+            else
+            {
+                sum[0] += 1.99344265;
+            }
+        }
+    }
+    else
+    {
+        if (sample[0] < 199.5)
+        {
+            if (sample[2] < 33.5)
+            {
+                if (sample[0] < 63.5)
+                {
+                    sum[0] += -1.99145293;
+                }
+                else
+                {
+                    if (sample[0] < 69.5)
+                    {
+                        sum[0] += 0.5;
+                    }
+                    else
+                    {
+                        sum[0] += 1.9375;
+                    }
+                }
+            }
+            else
+            {
+                if (sample[2] < 64.5)
+                {
+                    if (sample[0] < 84.5)
+                    {
+                        if (sample[0] < 81.5)
+                        {
+                            sum[0] += -1.99540007;
+                        }
+                        else
+                        {
+                            sum[0] += -0.571428597;
+                        }
+                    }
+                    else
+                    {
+                        if (sample[0] < 93.5)
+                        {
+                            sum[0] += 0.923076928;
+                        }
+                        else
+                        {
+                            sum[0] += 1.95375717;
+                        }
+                    }
+                }
+                else
+                {
+                    sum[0] += -1.99684238;
+                }
+            }
+        }
+        else
+        {
+            if (sample[1] < 177)
+            {
+                sum[0] += 1.954023;
+            }
+            else
+            {
+                sum[0] += -1.99136066;
+            }
+        }
+    }
+
+    return sum;
+}
+
+}  // namespace trifinger_object_tracking

--- a/src/xgb_single_color/segment_image.cpp
+++ b/src/xgb_single_color/segment_image.cpp
@@ -1,0 +1,58 @@
+#include <trifinger_object_tracking/xgboost_classifier_single_color_rgb.h>
+
+namespace trifinger_object_tracking
+{
+cv::Mat segment_image(const cv::Mat &image_bgr)
+{
+    cv::Mat blurred_image_bgr;
+
+    // initialise mask to same shape as input image but single-channel
+    cv::Mat mask(image_bgr.rows, image_bgr.cols, CV_8UC1, cv::Scalar(0));
+
+    // blur the image to make colour classification easier
+    cv::medianBlur(image_bgr, blurred_image_bgr, 5);
+    // cv::cvtColor(blurred_image_bgr, image_hsv_, cv::COLOR_BGR2HSV);
+
+    // structuring element for denoising
+    constexpr unsigned OPEN_RADIUS = 1;
+    static const cv::Mat open_kernel = cv::getStructuringElement(
+        cv::MORPH_ELLIPSE, cv::Size(2 * OPEN_RADIUS + 1, 2 * OPEN_RADIUS + 1));
+
+    for (int r = 0; r < blurred_image_bgr.rows; r += 1)
+    {
+        for (int c = 0; c < blurred_image_bgr.cols; c += 1)
+        {
+            std::array<float, XGB_NUM_FEATURES> features;
+
+            cv::Vec3b bgr = blurred_image_bgr.at<cv::Vec3b>(r, c);
+            // cv::Vec3b hsv = image_hsv_.at<cv::Vec3b>(r, c);
+
+            features[0] = static_cast<float>(bgr[0]);
+            features[1] = static_cast<float>(bgr[1]);
+            features[2] = static_cast<float>(bgr[2]);
+            // features[3] = static_cast<float>(hsv[0]);
+            // features[4] = static_cast<float>(hsv[1]);
+            // features[5] = static_cast<float>(hsv[2]);
+
+            std::array<float, XGB_NUM_CLASSES> probabilities =
+                xgb_classify(features);
+
+            // It seems that for a binary classification, the xgboost model only
+            // has a single output.  So instead of looking for the class with
+            // the highest value, we have to threshold this single value
+
+            // TODO: what is the correct threshold?
+            if (probabilities[0] > 0)
+            {
+                mask.at<uint8_t>(r, c) = 255;
+            }
+        }
+    }
+
+    // "open" image to get rid of single-pixel noise
+    cv::morphologyEx(mask, mask, cv::MORPH_OPEN, open_kernel);
+
+    return mask;
+}
+
+}  // namespace trifinger_object_tracking

--- a/srcpy/py_lightblue_segmenter.cpp
+++ b/srcpy/py_lightblue_segmenter.cpp
@@ -1,0 +1,20 @@
+/**
+ * @file
+ * @brief Python bindings for the lightblue colour segmentation
+ * @copyright 2020, Max Planck Gesellschaft.  All rights reserved.
+ */
+#include <pybind11/embed.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <pybind11_opencv/cvbind.hpp>
+
+#include <trifinger_object_tracking/xgboost_classifier_single_color_rgb.h>
+
+PYBIND11_MODULE(py_lightblue_segmenter, m)
+{
+    m.def("segment_image",
+          &trifinger_object_tracking::segment_image,
+          "Segment the lightblue areas of the given image.",
+          pybind11::call_guard<pybind11::gil_scoped_release>());
+}


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Add a library to segment images based on a xgboost model with binary
output (e.g. looking for a single colour).  The specific library is for
the "lightblue" dice but equivalent segmeters with different objectives
(e.g. other colour) can easily be added by adding another library in
CMakeListst.txt with only the `lightblue_rgb.cpp` replaced.

The current "lightblue" model is a preliminary one, that is only trained on a single camera observation.  It already works quite well but is likely to be replaced by a better one in the future.

## How I Tested

By running the accompanying demos.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
