### PR TITLE
fix: Explicitly copy images in pyBullet driver

### DIFF
--- a/src/pybullet_tricamera_object_tracker_driver.cpp
+++ b/src/pybullet_tricamera_object_tracker_driver.cpp
@@ -73,7 +73,10 @@ PyBulletTriCameraObjectTrackerDriver::get_observation()
                 // ensure that the image array is contiguous in memory,
                 // otherwise conversion to cv::Mat would fail
                 auto image = numpy_.attr("ascontiguousarray")(images[i]);
-                observation.cameras[i].image = image.cast<cv::Mat>();
+                cv::Mat image_cv = image.cast<cv::Mat>();
+                // explicitly copy to ensure it is not pointing to some data
+                // that later gets invalid
+                observation.cameras[i].image = image_cv.clone();
             }
         }
 


### PR DESCRIPTION


[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Explicitly copy to make sure the data pointer is not getting invalid as
the original memory gets overwritten.


## How I Tested

By running it and checking that the images of all three cameras look correct.



## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
