### PR TITLE
Reduce window size of medianBlur to 3

### DIFF
--- a/src/xgb_single_color/segment_image.cpp
+++ b/src/xgb_single_color/segment_image.cpp
@@ -10,7 +10,7 @@ cv::Mat segment_image(const cv::Mat &image_bgr)
     cv::Mat mask(image_bgr.rows, image_bgr.cols, CV_8UC1, cv::Scalar(0));
 
     // blur the image to make colour classification easier
-    cv::medianBlur(image_bgr, blurred_image_bgr, 5);
+    cv::medianBlur(image_bgr, blurred_image_bgr, 3);
     // cv::cvtColor(blurred_image_bgr, image_hsv_, cv::COLOR_BGR2HSV);
 
     // structuring element for denoising


### PR DESCRIPTION
## Description

Reducing the window size to 3 leads to a slight degradation of the segmentation accuracy but the result is still acceptable while the time needed segment one image is reduced by factor 3 (from ~1.5 to ~0.5 ms on my laptop).

Example:
| ksize = 5 (old value) | ksize = 3 (new value) |
| --------------------------| -------------------------------|
| ![ksize5](https://user-images.githubusercontent.com/9333121/125315696-a96afe80-e337-11eb-82c1-febbfcdad313.png) | ![ksize3](https://user-images.githubusercontent.com/9333121/125315718-ae2fb280-e337-11eb-8d84-360cf208a200.png) |


## How I Tested

By running it on a set of test images (see example above) and measuring the average time for segmenting a single image.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
