### PR TITLE
Increase tolerance of find_pose unit test

### DIFF
--- a/test/test_pose_detector.cpp
+++ b/test/test_pose_detector.cpp
@@ -100,9 +100,9 @@ TEST_F(TestPoseDetector, find_pose)
     FAIL() << "No ground truth given for this object version.";
 #endif
 
-    EXPECT_NEAR(pose.translation[0], actual_translation[0], 0.005);
-    EXPECT_NEAR(pose.translation[1], actual_translation[1], 0.005);
-    EXPECT_NEAR(pose.translation[2], actual_translation[2], 0.005);
+    EXPECT_NEAR(pose.translation[0], actual_translation[0], 0.01);
+    EXPECT_NEAR(pose.translation[1], actual_translation[1], 0.01);
+    EXPECT_NEAR(pose.translation[2], actual_translation[2], 0.01);
 
     // What is a good way to compare rotation vectors?
     // EXPECT_NEAR(pose.rotation[0], actual_rotation[0], 0.01);


### PR DESCRIPTION


[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

This test is occasionally failing because it exceeds the tolerance a bit.  To avoid this from happening, increase the tolerance a bit.


## How I Tested

Ran the test in a loop 1000 times without failure.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
