### PR TITLE
fix: Set filtered_object_pose in PyBullet driver

### DIFF
--- a/src/pybullet_tricamera_object_tracker_driver.cpp
+++ b/src/pybullet_tricamera_object_tracker_driver.cpp
@@ -88,6 +88,9 @@ PyBulletTriCameraObjectTrackerDriver::get_observation()
     // there is no noise in the simulation
     observation.object_pose.confidence = 1.0;
 
+    // no noise, so no actual filtering needed
+    observation.filtered_object_pose = observation.object_pose;
+
     return observation;
 }
 


### PR DESCRIPTION
## Description

Set filtered_object_pose in PyBullet driver.  There is no noise in the simulation, so simply set filtered = unfiltered.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
