### PR TITLE
Extend CubeVisualizer

### DIFF
--- a/include/trifinger_object_tracking/cube_visualizer.hpp
+++ b/include/trifinger_object_tracking/cube_visualizer.hpp
@@ -60,16 +60,56 @@ public:
      *  corresponding colours.  The latter allows to verify the orientation
      *  (i.e. which face is pointing into which direction) but occludes more of
      *  the image.
+     * @param opacity  Opacity of the visualisation (in range [0, 1]).
      *
      * @return Images with the object visualisation.
      */
     std::array<cv::Mat, N_CAMERAS> draw_cube(
         const std::array<cv::Mat, N_CAMERAS> &images,
         const ObjectPose &object_pose,
-        bool fill_faces = false);
+        bool fill_faces = false,
+        float opacity = 0.5);
+
+    /**
+     * @brief Draw a circle into the images enclosing the object at the
+     *        specified pose.
+     *
+     * @param images  Images from the cameras.  The images need to be ordered in
+     *  the same way as the camera calibration parameters that are passed to the
+     *  constructor.
+     * @param object_pose  Pose of the object.
+     * @param fill  If true a filled circle is drawn with some transparency.  If
+     *  false, only a solid contour is drawn.
+     * @param opacity  Opacity of the visualisation (in range [0, 1]).
+     * @param scale  Scale factor for the circle size.  At 1.0 the cube is just
+     *  fully enclosed.
+     *
+     * @return Images with the object visualisation.
+     */
+    std::array<cv::Mat, N_CAMERAS> draw_circle(
+        const std::array<cv::Mat, N_CAMERAS> &images,
+        const ObjectPose &object_pose,
+        bool fill = true,
+        float opacity = 0.5,
+        float scale = 1.0);
 
 private:
     BaseCuboidModel::ConstPtr cube_model_;
     PoseDetector pose_detector_;
+
+    //! Get projected corner points for the given object pose.
+    std::vector<std::vector<cv::Point2f>> get_projected_points(
+        const ObjectPose &object_pose);
+
+    //! Draw cube with filled faces in the given image
+    void draw_filled_cube(cv::Mat &image,
+                          size_t camera_index,
+                          const PoseDetector &pose_detector,
+                          const std::vector<cv::Point2f> &imgpoints);
+
+    //! Draw wireframe cube in the given image
+    void draw_cube_wireframe(cv::Mat &image,
+                             size_t camera_index,
+                             const std::vector<cv::Point2f> &imgpoints);
 };
 }  // namespace trifinger_object_tracking

--- a/scripts/tricamera_log_viewer.py
+++ b/scripts/tricamera_log_viewer.py
@@ -153,10 +153,12 @@ def main():
             object_pose = observation.filtered_object_pose
 
         if args.visualize_goal_pose:
-            images = cube_visualizer.draw_cube(images, goal_pose, True)
+            images = cube_visualizer.draw_cube(images, goal_pose, fill=True)
 
         if args.visualize_object_pose:
-            images = cube_visualizer.draw_cube(images, object_pose, False)
+            images = cube_visualizer.draw_cube(
+                images, object_pose, fill=False, opacity=0.8
+            )
 
         if args.show_confidence:
             images = [

--- a/src/cube_visualizer.cpp
+++ b/src/cube_visualizer.cpp
@@ -5,7 +5,122 @@ namespace trifinger_object_tracking
 std::array<cv::Mat, CubeVisualizer::N_CAMERAS> CubeVisualizer::draw_cube(
     const std::array<cv::Mat, CubeVisualizer::N_CAMERAS> &images,
     const ObjectPose &object_pose,
-    bool fill_faces)
+    bool fill,
+    float alpha)
+{
+    std::array<cv::Mat, CubeVisualizer::N_CAMERAS> out_images;
+
+    auto projected_cube_corners = get_projected_points(object_pose);
+    for (size_t i = 0; i < N_CAMERAS; i++)
+    {
+        out_images[i] = images[i].clone();
+        std::vector<cv::Point2f> imgpoints = projected_cube_corners[i];
+
+        if (fill)
+        {
+            draw_filled_cube(out_images[i], i, pose_detector_, imgpoints);
+        }
+        else
+        {
+            draw_cube_wireframe(out_images[i], i, imgpoints);
+        }
+
+        if (alpha < 1)
+        {
+            cv::addWeighted(
+                out_images[i], alpha, images[i], 1 - alpha, 0, out_images[i]);
+        }
+    }
+
+    return out_images;
+}
+
+std::array<cv::Mat, CubeVisualizer::N_CAMERAS> CubeVisualizer::draw_circle(
+    const std::array<cv::Mat, CubeVisualizer::N_CAMERAS> &images,
+    const ObjectPose &object_pose,
+    bool fill,
+    float alpha,
+    float scale)
+{
+    std::array<cv::Mat, CubeVisualizer::N_CAMERAS> out_images;
+    int thickness = fill ? cv::FILLED : 2;
+
+    auto projected_cube_corners = get_projected_points(object_pose);
+    for (size_t i = 0; i < N_CAMERAS; i++)
+    {
+        out_images[i] = images[i].clone();
+        std::vector<cv::Point2f> imgpoints = projected_cube_corners[i];
+        cv::Point2f center;
+        float radius;
+
+        cv::minEnclosingCircle(imgpoints, center, radius);
+        radius *= scale;
+        cv::circle(
+            out_images[i], center, radius, cv::Scalar(50, 180, 0), thickness);
+
+        if (alpha < 1)
+        {
+            cv::addWeighted(
+                out_images[i], alpha, images[i], 1 - alpha, 0, out_images[i]);
+        }
+    }
+
+    return out_images;
+}
+
+void CubeVisualizer::draw_filled_cube(cv::Mat &image,
+                                      size_t camera_index,
+                                      const PoseDetector &pose_detector,
+                                      const std::vector<cv::Point2f> &imgpoints)
+{
+    for (auto [color, corner_indices] :
+         pose_detector.get_visible_faces(camera_index))
+    {
+        auto rgb = cube_model_->get_rgb(color);
+
+        std::vector<cv::Point> corners = {imgpoints[corner_indices[0]],
+                                          imgpoints[corner_indices[1]],
+                                          imgpoints[corner_indices[2]],
+                                          imgpoints[corner_indices[3]]};
+
+        cv::fillConvexPoly(image, corners, cv::Scalar(rgb[2], rgb[1], rgb[0]));
+    }
+}
+
+void CubeVisualizer::draw_cube_wireframe(
+    cv::Mat &image,
+    size_t camera_index,
+    const std::vector<cv::Point2f> &imgpoints)
+{
+    // draw all the cube edges in the out_images[i]
+    for (auto &it : cube_model_->edges)
+    {
+        cv::line(image,
+                 imgpoints[it.second.c1],
+                 imgpoints[it.second.c2],
+                 cv::Scalar(100, 50, 0),
+                 2);
+    }
+
+    // over-draw with the visible edges in a brighter colour
+    for (auto [color, corner_indices] :
+         pose_detector_.get_visible_faces(camera_index))
+    {
+        (void)color;  // suppress unused warning
+
+        for (size_t ci = 0; ci < 4; ci++)
+        {
+            cv::line(image,
+                     imgpoints[corner_indices[ci]],
+                     imgpoints[corner_indices[(ci + 1) % 4]],
+                     cv::Scalar(255, 100, 0),
+                     2);
+        }
+    }
+}
+
+std::vector<std::vector<cv::Point2f>> CubeVisualizer::get_projected_points(
+    const ObjectPose &object_pose)
 {
     std::array<cv::Mat, CubeVisualizer::N_CAMERAS> out_images;
 
@@ -30,59 +145,7 @@ std::array<cv::Mat, CubeVisualizer::N_CAMERAS> CubeVisualizer::draw_cube(
 
     pose_detector_.set_pose(pose);
 
-    auto projected_cube_corners = pose_detector_.get_projected_points();
-    for (size_t i = 0; i < N_CAMERAS; i++)
-    {
-        out_images[i] = images[i].clone();
-
-        std::vector<cv::Point2f> imgpoints = projected_cube_corners[i];
-
-        if (fill_faces)
-        {
-            for (auto [color, corner_indices] :
-                 pose_detector_.get_visible_faces(i))
-            {
-                auto rgb = cube_model_->get_rgb(color);
-
-                std::vector<cv::Point> corners = {imgpoints[corner_indices[0]],
-                                                  imgpoints[corner_indices[1]],
-                                                  imgpoints[corner_indices[2]],
-                                                  imgpoints[corner_indices[3]]};
-                cv::fillConvexPoly(out_images[i],
-                                   corners,
-                                   cv::Scalar(rgb[2], rgb[1], rgb[0], 0.7));
-            }
-        }
-        else
-        {
-            // draw all the cube edges in the out_images[i]
-            for (auto &it : cube_model_->edges)
-            {
-                cv::line(out_images[i],
-                         imgpoints[it.second.c1],
-                         imgpoints[it.second.c2],
-                         cv::Scalar(100, 50, 0),
-                         2);
-            }
-
-            // over-draw with the visible edges in a brighter colour
-            for (auto [color, corner_indices] :
-                 pose_detector_.get_visible_faces(i))
-            {
-                (void)color;  // suppress unused warning
-
-                for (size_t ci = 0; ci < 4; ci++)
-                {
-                    cv::line(out_images[i],
-                             imgpoints[corner_indices[ci]],
-                             imgpoints[corner_indices[(ci + 1) % 4]],
-                             cv::Scalar(255, 100, 0),
-                             2);
-                }
-            }
-        }
-    }
-
-    return out_images;
+    return pose_detector_.get_projected_points();
 }
+
 }  // namespace trifinger_object_tracking

--- a/srcpy/py_tricamera_types.cpp
+++ b/srcpy/py_tricamera_types.cpp
@@ -85,5 +85,17 @@ PYBIND11_MODULE(py_tricamera_types, m)
     pybind11::class_<CubeVisualizer>(m, "CubeVisualizer")
         .def(pybind11::init<BaseCuboidModel::ConstPtr,
                             std::array<std::string, 3>>())
-        .def("draw_cube", &CubeVisualizer::draw_cube);
+        .def("draw_cube",
+             &CubeVisualizer::draw_cube,
+             pybind11::arg("images"),
+             pybind11::arg("object_pose"),
+             pybind11::arg("fill") = true,
+             pybind11::arg("opacity") = 0.5)
+        .def("draw_circle",
+             &CubeVisualizer::draw_circle,
+             pybind11::arg("images"),
+             pybind11::arg("object_pose"),
+             pybind11::arg("fill") = true,
+             pybind11::arg("opacity") = 0.5,
+             pybind11::arg("scale") = 1.0);
 }


### PR DESCRIPTION
## Description

- Properly implement transparency and add `opacity` argument to
  `draw_cube()`.
- Add `draw_circle()` which visualises a circle that encloses the cube
  corners.
- Refactor a bit to avoid code duplication.


## How I Tested
By running tricamera_log_viewer with some local modification to test all combinations of arguments.

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
