### PR TITLE
chore: Use run-clang-format from mpi_cmake_modules

### DIFF
--- a/.github/workflows/style_checker.yml
+++ b/.github/workflows/style_checker.yml
@@ -17,6 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - run: wget https://raw.githubusercontent.com/luator/run-clang-format/master/run-clang-format.py
+      - run: wget https://raw.githubusercontent.com/machines-in-motion/mpi_cmake_modules/master/scripts/run-clang-format
       - run: wget https://raw.githubusercontent.com/machines-in-motion/mpi_cmake_modules/master/resources/_clang-format
-      - run: python ./run-clang-format.py -r .
+      - run: python ./run-clang-format -r .


### PR DESCRIPTION
## Description

Use run-clang-format from mpi_cmake_modules.


## How I Tested

Through this PR.