### PR TITLE
fix build issues on Ubuntu 22.04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   ([cli_utils](https://github.com/MPI-IS/cli_utils)).  Thus it is removed from
   this package and the one from cli_utils is used instead.
 
+### Fixed
+- pybind11 build error on Ubuntu 22.04
+
 
 ## [1.1.0] - 2022-07-29
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,9 +15,14 @@ string(APPEND CMAKE_CXX_FLAGS " -Wall -Wextra -Wfatal-errors -Werror=return-type
 # always enable optimization, otherwise object tracking is too slow
 string(APPEND CMAKE_CXX_FLAGS " -O3")
 
+# pybind11 needs to be first, otherwise other packages which also search for
+# Python can cause an 'Unknown CMake command "python3_add_library"' error.
+# Probably related to how Python is found, see
+# https://github.com/pybind/pybind11/issues/3996
+find_package(pybind11 REQUIRED)
+
 find_package(ament_cmake REQUIRED)
 find_package(mpi_cmake_modules REQUIRED)
-find_package(pybind11 REQUIRED)
 find_package(pybind11_opencv REQUIRED)
 find_package(cli_utils REQUIRED)
 find_package(serialization_utils REQUIRED)

--- a/include/trifinger_object_tracking/cube_model.hpp
+++ b/include/trifinger_object_tracking/cube_model.hpp
@@ -8,6 +8,8 @@
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <stdexcept>
+#include <string>
 
 #include "color_model.hpp"
 


### PR DESCRIPTION
## Description
- find pybind11 before ament_cmake to fix error on Ubuntu 22.04
- add some missing includes

## How I Tested

By building and running tests.