### PR TITLE
chore: Update fixup commit check

### DIFF
--- a/.github/workflows/git_fixup.yml
+++ b/.github/workflows/git_fixup.yml
@@ -4,9 +4,9 @@ on: [pull_request]
 
 jobs:
   block-fixup:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Block Fixup Commit Merge
       uses: 13rac1/block-fixup-merge-action@v2.0.0


### PR DESCRIPTION
Switch to latest ubuntu container (18.04 is deprecated) and latest checkout action.
