### PR TITLE
doc: Remove obsolete argument

### DIFF
--- a/doc/b1_train_colour_segmentation.rst
+++ b/doc/b1_train_colour_segmentation.rst
@@ -24,7 +24,7 @@ run
 
 ::
 
-    ros2 run trifinger_cameras record_image_dataset --no-downsample -o <output_directory>
+    ros2 run trifinger_cameras record_image_dataset -o <output_directory>
 
 Every time you press Enter, images of all three cameras are acquired and stored
 together as a "snapshot" in the specified output directory.  So you can place


### PR DESCRIPTION
The behaviour of `record_image_dataset` has changed recently:  The default is now to not downsample and `--no-downsample` was removed accordingly.