### PR TITLE
Implement `get_sensor_info()` for drivers and refactor to reduce redundancy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add method `get_debug_image` to `TriCameraObjectTrackerDriver` and a script
   that uses it to create debug images from the cameras (this makes diagnosing
   issues with the object detection easier).
+- Support `trifinger_cameras::Settings` for changing camera configuration (see
+  documentation of `trifinger_cameras`).
+- Provide information about frame rate and camera parameters via `get_sensor_info()`
+  like in `trifinger_cameras`.  For this, overloaded constructors are added to the
+  driver classes which accept camera info files instead of device IDs.
 
 ### Removed
 - The `ProgramOptions` class has been moved to its own package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Provide information about frame rate and camera parameters via `get_sensor_info()`
   like in `trifinger_cameras`.  For this, overloaded constructors are added to the
   driver classes which accept camera info files instead of device IDs.
+- Add a "backend-only" mode to `demo_cameras`.  Use this if the front end is running in
+  a separate process.
 
 ### Removed
 - The `ProgramOptions` class has been moved to its own package
   ([cli_utils](https://github.com/MPI-IS/cli_utils)).  Thus it is removed from
   this package and the one from cli_utils is used instead.
+- Option `--multi-process` from `demo_cameras`.  Use `--frontend-only` instead.
 
 ### Fixed
 - pybind11 build error on Ubuntu 22.04

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,7 @@ target_link_libraries(pybullet_tricamera_object_tracker_driver
     pybind11_opencv::pybind11_opencv
     robot_interfaces::robot_interfaces
     serialization_utils::serialization_utils
+    trifinger_cameras::pybullet_tricamera_driver
     cube_detector
 )
 # using pybind11 types, therefore visibility needs to be hidden

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED on)
 # fails
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+# generate compile_commands.json by default (needed for LSP)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # stop build on first error
 string(APPEND CMAKE_CXX_FLAGS " -Wall -Wextra -Wfatal-errors -Werror=return-type")
 
@@ -138,7 +141,7 @@ if (${HAS_PYLON_DRIVERS})
     )
     target_link_libraries(tricamera_object_tracking_driver
         robot_interfaces::robot_interfaces
-        trifinger_cameras::pylon_driver
+        trifinger_cameras::tricamera_driver
         cube_detector
     )
 

--- a/demos/demo_cameras.py
+++ b/demos/demo_cameras.py
@@ -2,66 +2,44 @@
 """Demo on how to access observations from the TriCameraObjectTrackerDriver."""
 
 import argparse
+import sys
 import time
 
 import cv2
 import numpy as np
 
-import trifinger_object_tracking.py_object_tracker
+import signal_handler
+import trifinger_object_tracking.py_object_tracker as object_tracker
 import trifinger_object_tracking.py_tricamera_types as tricamera
 from trifinger_cameras import utils
 
 
-def main() -> None:  # noqa: D103
-    argparser = argparse.ArgumentParser(description=__doc__)
-    argparser.add_argument(
-        "--multi-process",
-        action="store_true",
-        help="""If set, use multiprocess camera data to access backend in other
-            process.  Otherwise run the backend locally.
-        """,
-    )
-    argparser.add_argument(
-        "--object",
-        type=str,
-        default="cube_v2",
-        help="Name of the model used for object detection.  Default: %(default)s.",
-    )
-    args = argparser.parse_args()
+camera_names = ["camera60", "camera180", "camera300"]
+calib_files = [
+    "/etc/trifingerpro/camera60_cropped_and_downsampled.yml",
+    "/etc/trifingerpro/camera180_cropped_and_downsampled.yml",
+    "/etc/trifingerpro/camera300_cropped_and_downsampled.yml",
+]
 
-    camera_names = ["camera60", "camera180", "camera300"]
 
-    model = trifinger_object_tracking.py_object_tracker.get_model_by_name(args.object)
+def back_end_only_loop() -> None:
+    """Idle loop for the back-end-only mode."""
+    print("Backend is running.  Press Ctrl-C to stop.")
+    signal_handler.init()
+    while not signal_handler.has_received_sigint():
+        time.sleep(1)
 
-    if args.multi_process:
-        camera_data = tricamera.MultiProcessData("tricamera", False)
-    else:
-        camera_data = tricamera.SingleProcessData()
-        camera_driver = tricamera.TriCameraObjectTrackerDriver(
-            *camera_names, cube_model=model
-        )
-        camera_backend = tricamera.Backend(camera_driver, camera_data)
 
+def front_end_loop(
+    camera_data: tricamera.BaseData, model: object_tracker.BaseCuboidModel
+) -> None:
+    """Run the front end to display camera images with visualized object pose."""
     camera_frontend = tricamera.Frontend(camera_data)
 
-    calib_files = [
-        "/etc/trifingerpro/camera60_cropped_and_downsampled.yml",
-        "/etc/trifingerpro/camera180_cropped_and_downsampled.yml",
-        "/etc/trifingerpro/camera300_cropped_and_downsampled.yml",
-    ]
     cube_visualizer = tricamera.CubeVisualizer(model, calib_files)
 
-    np.set_printoptions(precision=3, suppress=True)
-    print("=== Camera Info: ======================")
-    for i, info in enumerate(camera_frontend.get_sensor_info().camera):
-        print(f"--- Camera {i}: ----------------------")
-        print(f"fps: {info.frame_rate_fps}")
-        print(f"width x height: {info.image_width}x{info.image_height}")
-        print(info.camera_matrix)
-        print(info.distortion_coefficients)
-        print(info.tf_world_to_camera)
-        print("---------------------------------------")
-    print("=======================================")
+    print("=== Camera Info: ===")
+    utils.print_tricamera_sensor_info(camera_frontend.get_sensor_info())
 
     last_print = time.time()
     while True:
@@ -84,9 +62,71 @@ def main() -> None:  # noqa: D103
         if cv2.waitKey(3) in [ord("q"), 27]:  # 27 = ESC
             break
 
-    if not args.multi_process:
+
+def main() -> int:  # noqa: D103
+    parser = argparse.ArgumentParser(description=__doc__)
+
+    mode_group = parser.add_mutually_exclusive_group()
+    mode_group.add_argument(
+        "--frontend-only",
+        action="store_const",
+        dest="mode",
+        const="frontend-only",
+        help="""Run only the front end, using multi-process camera data.  In this case,
+            the back end has to be run in a separate process.
+        """,
+    )
+    mode_group.add_argument(
+        "--backend-only",
+        action="store_const",
+        dest="mode",
+        const="backend-only",
+        help="""Run only the back end, using multi-process camera data.  In this case,
+            the front end has to be run in a separate process.
+        """,
+    )
+    mode_group.add_argument(
+        "--single-process",
+        action="store_const",
+        dest="mode",
+        const="single-process",
+        help="Run both front and back end, using single-process camera data.",
+    )
+    mode_group.set_defaults(mode="single-process")
+
+    parser.add_argument(
+        "--object",
+        type=str,
+        default="cube_v2",
+        help="Name of the model used for object detection.  Default: %(default)s.",
+    )
+    args = parser.parse_args()
+
+    model = object_tracker.get_model_by_name(args.object)
+
+    if args.mode == "single-process":
+        camera_data = tricamera.SingleProcessData()
+    else:
+        camera_data = tricamera.MultiProcessData("tricamera", False)
+
+    if args.mode != "frontend-only":
+        camera_driver = tricamera.TriCameraObjectTrackerDriver(
+            *camera_names, cube_model=model
+        )
+        camera_backend = tricamera.Backend(camera_driver, camera_data)
+    else:
+        camera_backend = None
+
+    if args.mode == "backend-only":
+        back_end_only_loop()
+    else:
+        front_end_loop(camera_data, model)
+
+    if camera_backend is not None:
         camera_backend.shutdown()
+
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/demos/demo_cameras.py
+++ b/demos/demo_cameras.py
@@ -2,6 +2,7 @@
 """Demo on how to access observations from the TriCameraObjectTrackerDriver."""
 
 import argparse
+import pathlib
 import sys
 import time
 
@@ -16,9 +17,9 @@ from trifinger_cameras import utils
 
 camera_names = ["camera60", "camera180", "camera300"]
 calib_files = [
-    "/etc/trifingerpro/camera60_cropped_and_downsampled.yml",
-    "/etc/trifingerpro/camera180_cropped_and_downsampled.yml",
-    "/etc/trifingerpro/camera300_cropped_and_downsampled.yml",
+    pathlib.Path("/etc/trifingerpro/camera60_cropped_and_downsampled.yml"),
+    pathlib.Path("/etc/trifingerpro/camera180_cropped_and_downsampled.yml"),
+    pathlib.Path("/etc/trifingerpro/camera300_cropped_and_downsampled.yml"),
 ]
 
 
@@ -36,7 +37,7 @@ def front_end_loop(
     """Run the front end to display camera images with visualized object pose."""
     camera_frontend = tricamera.Frontend(camera_data)
 
-    cube_visualizer = tricamera.CubeVisualizer(model, calib_files)
+    cube_visualizer = tricamera.CubeVisualizer(model, [str(f) for f in calib_files])
 
     print("=== Camera Info: ===")
     utils.print_tricamera_sensor_info(camera_frontend.get_sensor_info())
@@ -111,7 +112,7 @@ def main() -> int:  # noqa: D103
 
     if args.mode != "frontend-only":
         camera_driver = tricamera.TriCameraObjectTrackerDriver(
-            *camera_names, cube_model=model
+            *calib_files, cube_model=model
         )
         camera_backend = tricamera.Backend(camera_driver, camera_data)
     else:

--- a/demos/demo_cameras.py
+++ b/demos/demo_cameras.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
-"""
-Demo on how to access observations from the TriCameraObjectTrackerDriver.
-"""
+"""Demo on how to access observations from the TriCameraObjectTrackerDriver."""
+
 import argparse
 import time
 
@@ -13,7 +12,7 @@ import trifinger_object_tracking.py_tricamera_types as tricamera
 from trifinger_cameras import utils
 
 
-def main():
+def main() -> None:  # noqa: D103
     argparser = argparse.ArgumentParser(description=__doc__)
     argparser.add_argument(
         "--multi-process",
@@ -32,9 +31,7 @@ def main():
 
     camera_names = ["camera60", "camera180", "camera300"]
 
-    model = trifinger_object_tracking.py_object_tracker.get_model_by_name(
-        args.object
-    )
+    model = trifinger_object_tracking.py_object_tracker.get_model_by_name(args.object)
 
     if args.multi_process:
         camera_data = tricamera.MultiProcessData("tricamera", False)
@@ -54,15 +51,23 @@ def main():
     ]
     cube_visualizer = tricamera.CubeVisualizer(model, calib_files)
 
+    np.set_printoptions(precision=3, suppress=True)
+    print("=== Camera Info: ======================")
+    for i, info in enumerate(camera_frontend.get_sensor_info().camera):
+        print(f"--- Camera {i}: ----------------------")
+        print(f"fps: {info.frame_rate_fps}")
+        print(f"width x height: {info.image_width}x{info.image_height}")
+        print(info.camera_matrix)
+        print(info.distortion_coefficients)
+        print(info.tf_world_to_camera)
+        print("---------------------------------------")
+    print("=======================================")
+
     last_print = time.time()
     while True:
         observation = camera_frontend.get_latest_observation()
-        images = [
-            utils.convert_image(camera.image) for camera in observation.cameras
-        ]
-        images = cube_visualizer.draw_cube(
-            images, observation.object_pose, False
-        )
+        images = [utils.convert_image(camera.image) for camera in observation.cameras]
+        images = cube_visualizer.draw_cube(images, observation.object_pose, False)
 
         stacked_image = np.hstack(images)
         cv2.imshow(" | ".join(camera_names), stacked_image)
@@ -70,9 +75,7 @@ def main():
         now = time.time()
         if (now - last_print) >= 1.0:
             print("-----")
-            print(
-                "Object Pose Confidence:", observation.object_pose.confidence
-            )
+            print("Object Pose Confidence:", observation.object_pose.confidence)
             print("Object Position:", observation.object_pose.position)
             print("Object Orientation:", observation.object_pose.orientation)
             last_print = now

--- a/demos/demo_cameras.py
+++ b/demos/demo_cameras.py
@@ -37,7 +37,9 @@ def front_end_loop(
     """Run the front end to display camera images with visualized object pose."""
     camera_frontend = tricamera.Frontend(camera_data)
 
-    cube_visualizer = tricamera.CubeVisualizer(model, [str(f) for f in calib_files])
+    cube_visualizer = tricamera.CubeVisualizer(
+        model, [str(f) for f in calib_files]
+    )
 
     print("=== Camera Info: ===")
     utils.print_tricamera_sensor_info(camera_frontend.get_sensor_info())
@@ -45,8 +47,12 @@ def front_end_loop(
     last_print = time.time()
     while True:
         observation = camera_frontend.get_latest_observation()
-        images = [utils.convert_image(camera.image) for camera in observation.cameras]
-        images = cube_visualizer.draw_cube(images, observation.object_pose, False)
+        images = [
+            utils.convert_image(camera.image) for camera in observation.cameras
+        ]
+        images = cube_visualizer.draw_cube(
+            images, observation.object_pose, False
+        )
 
         stacked_image = np.hstack(images)
         cv2.imshow(" | ".join(camera_names), stacked_image)
@@ -54,7 +60,9 @@ def front_end_loop(
         now = time.time()
         if (now - last_print) >= 1.0:
             print("-----")
-            print("Object Pose Confidence:", observation.object_pose.confidence)
+            print(
+                "Object Pose Confidence:", observation.object_pose.confidence
+            )
             print("Object Position:", observation.object_pose.position)
             print("Object Orientation:", observation.object_pose.orientation)
             last_print = now

--- a/include/trifinger_object_tracking/pybullet_tricamera_object_tracker_driver.hpp
+++ b/include/trifinger_object_tracking/pybullet_tricamera_object_tracker_driver.hpp
@@ -48,8 +48,14 @@ public:
         bool render_images = true,
         trifinger_cameras::Settings settings = trifinger_cameras::Settings());
 
+    /**
+     * @brief Get the camera parameters (image size and calibration
+     * coefficients).
+     */
+    trifinger_cameras::TriCameraInfo get_sensor_info() override;
+
     //! @brief Get the latest observation.
-    trifinger_object_tracking::TriCameraObjectObservation get_observation();
+    trifinger_object_tracking::TriCameraObjectObservation get_observation() override;
 
 private:
     //! @brief PyBullet driver instance for rendering images.

--- a/include/trifinger_object_tracking/pybullet_tricamera_object_tracker_driver.hpp
+++ b/include/trifinger_object_tracking/pybullet_tricamera_object_tracker_driver.hpp
@@ -12,6 +12,7 @@
 #include <robot_interfaces/finger_types.hpp>
 #include <robot_interfaces/sensors/sensor_driver.hpp>
 #include <trifinger_cameras/camera_parameters.hpp>
+#include <trifinger_cameras/pybullet_tricamera_driver.hpp>
 
 #include <trifinger_object_tracking/tricamera_object_observation.hpp>
 
@@ -44,52 +45,18 @@ public:
     PyBulletTriCameraObjectTrackerDriver(
         pybind11::object tracking_object,
         robot_interfaces::TriFingerTypes::BaseDataPtr robot_data,
-        bool render_images = true)
-        : tracking_object_(tracking_object),
-          robot_data_(robot_data),
-          render_images_(render_images),
-          last_update_robot_time_index_(0)
-    {
-        // initialize Python interpreter if not already done
-        if (!Py_IsInitialized())
-        {
-            pybind11::initialize_interpreter();
-        }
-
-        pybind11::gil_scoped_acquire acquire;
-
-        if (render_images)
-        {
-            // some imports that are needed later for converting images (numpy
-            // array -> cv::Mat)
-            numpy_ = pybind11::module::import("numpy");
-
-            // TriFingerCameras gives access to the cameras in simulation
-            pybind11::module mod_camera =
-                pybind11::module::import("trifinger_simulation.camera");
-            cameras_ = mod_camera.attr("TriFingerCameras")();
-        }
-    }
+        bool render_images = true,
+        trifinger_cameras::Settings settings = trifinger_cameras::Settings());
 
     //! @brief Get the latest observation.
     trifinger_object_tracking::TriCameraObjectObservation get_observation();
 
 private:
-    //! @brief Python object to access cameras in pyBullet.
-    pybind11::object cameras_;
+    //! @brief PyBullet driver instance for rendering images.
+    trifinger_cameras::PyBulletTriCameraDriver camera_driver_;
 
     //! @brief Python object of the tracked object.
     pybind11::object tracking_object_;
-
-    robot_interfaces::TriFingerTypes::BaseDataPtr robot_data_;
-
-    //! @brief If false, no actual images are rendered.
-    bool render_images_;
-
-    //! @brief The numpy module.
-    pybind11::module numpy_;
-
-    time_series::Index last_update_robot_time_index_;
 };
 
 }  // namespace trifinger_object_tracking

--- a/include/trifinger_object_tracking/pybullet_tricamera_object_tracker_driver.hpp
+++ b/include/trifinger_object_tracking/pybullet_tricamera_object_tracker_driver.hpp
@@ -11,6 +11,8 @@
 
 #include <robot_interfaces/finger_types.hpp>
 #include <robot_interfaces/sensors/sensor_driver.hpp>
+#include <trifinger_cameras/camera_parameters.hpp>
+
 #include <trifinger_object_tracking/tricamera_object_observation.hpp>
 
 namespace trifinger_object_tracking
@@ -22,7 +24,8 @@ namespace trifinger_object_tracking
  */
 class PyBulletTriCameraObjectTrackerDriver
     : public robot_interfaces::SensorDriver<
-          trifinger_object_tracking::TriCameraObjectObservation>
+          trifinger_object_tracking::TriCameraObjectObservation,
+          trifinger_cameras::TriCameraInfo>
 {
 public:
     // For some reason the constructor needs to be in the header file to avoid a

--- a/include/trifinger_object_tracking/pybullet_tricamera_object_tracker_driver.hpp
+++ b/include/trifinger_object_tracking/pybullet_tricamera_object_tracker_driver.hpp
@@ -49,13 +49,19 @@ public:
         trifinger_cameras::Settings settings = trifinger_cameras::Settings());
 
     /**
-     * @brief Get the camera parameters (image size and calibration
-     * coefficients).
+     * @brief Get the camera parameters.
+     *
+     * @verbatim embed:rst:leading-asterisk
+     * Internally, this calls
+     * :cpp:func:`trifinger_cameras::PyBulletTriCameraDriver::get_sensor_info`,
+     * so see there fore more information.
+     * @endverbatim
      */
     trifinger_cameras::TriCameraInfo get_sensor_info() override;
 
     //! @brief Get the latest observation.
-    trifinger_object_tracking::TriCameraObjectObservation get_observation() override;
+    trifinger_object_tracking::TriCameraObjectObservation get_observation()
+        override;
 
 private:
     //! @brief PyBullet driver instance for rendering images.

--- a/include/trifinger_object_tracking/tricamera_object_observation.hpp
+++ b/include/trifinger_object_tracking/tricamera_object_observation.hpp
@@ -7,7 +7,7 @@
 
 #include <array>
 
-#include <trifinger_cameras/camera_observation.hpp>
+#include <trifinger_cameras/tricamera_observation.hpp>
 #include <trifinger_object_tracking/object_pose.hpp>
 
 namespace trifinger_object_tracking
@@ -16,16 +16,24 @@ namespace trifinger_object_tracking
  * @brief Observation of three cameras + object tracking
  */
 struct TriCameraObjectObservation
+    : public trifinger_cameras::TriCameraObservation
 {
-    std::array<trifinger_cameras::CameraObservation, 3> cameras;
+    trifinger_object_tracking::ObjectPose object_pose = {};
+    trifinger_object_tracking::ObjectPose filtered_object_pose = {};
 
-    trifinger_object_tracking::ObjectPose object_pose;
-    trifinger_object_tracking::ObjectPose filtered_object_pose;
+    TriCameraObjectObservation() = default;
+
+    TriCameraObjectObservation(
+        const trifinger_cameras::TriCameraObservation& observation)
+        : trifinger_cameras::TriCameraObservation(observation)
+    {
+    }
 
     template <class Archive>
     void serialize(Archive& archive)
     {
-        archive(cameras, object_pose, filtered_object_pose);
+        trifinger_cameras::TriCameraObservation::serialize(archive);
+        archive(object_pose, filtered_object_pose);
     }
 };
 

--- a/include/trifinger_object_tracking/tricamera_object_tracking_driver.hpp
+++ b/include/trifinger_object_tracking/tricamera_object_tracking_driver.hpp
@@ -8,7 +8,11 @@
 #include <chrono>
 
 #include <robot_interfaces/sensors/sensor_driver.hpp>
+#include <trifinger_cameras/camera_parameters.hpp>
 #include <trifinger_cameras/pylon_driver.hpp>
+#include <trifinger_cameras/settings.hpp>
+#include <trifinger_cameras/tricamera_driver.hpp>
+
 #include <trifinger_object_tracking/cube_detector.hpp>
 #include <trifinger_object_tracking/tricamera_object_observation.hpp>
 
@@ -19,7 +23,8 @@ namespace trifinger_object_tracking
  * and get observations from them.
  */
 class TriCameraObjectTrackerDriver
-    : public robot_interfaces::SensorDriver<TriCameraObjectObservation>
+    : public robot_interfaces::SensorDriver<TriCameraObjectObservation,
+                                            trifinger_cameras::TriCameraInfo>
 {
 public:
     //! @brief Rate at which images are acquired.
@@ -35,18 +40,21 @@ public:
      * @param cube_model The model that is used for detecting the cube.
      * @param downsample_images If set to true (default), images are
      *     downsampled to half their original size.
+     * @param settings Settings for the cameras.
      */
-    TriCameraObjectTrackerDriver(const std::string& device_id_1,
-                                 const std::string& device_id_2,
-                                 const std::string& device_id_3,
-                                 BaseCuboidModel::ConstPtr cube_model,
-                                 bool downsample_images = true);
+    TriCameraObjectTrackerDriver(
+        const std::string& device_id_1,
+        const std::string& device_id_2,
+        const std::string& device_id_3,
+        BaseCuboidModel::ConstPtr cube_model,
+        bool downsample_images = true,
+        trifinger_cameras::Settings settings = trifinger_cameras::Settings());
 
     /**
      * @brief Get the latest observation from the three cameras.
      * @return TricameraObservation
      */
-    TriCameraObjectObservation get_observation();
+    TriCameraObjectObservation get_observation() override;
 
     /**
      * @brief Fetch an observation from the cameras and create a debug image.
@@ -62,9 +70,10 @@ public:
     cv::Mat get_debug_image(bool fill_faces = false);
 
 private:
-    std::array<trifinger_cameras::PylonDriver, N_CAMERAS> cameras_;
+    trifinger_cameras::TriCameraDriver camera_driver_;
+    // std::array<trifinger_cameras::PylonDriver, N_CAMERAS> cameras_;
     trifinger_object_tracking::CubeDetector cube_detector_;
-    std::chrono::time_point<std::chrono::system_clock> last_update_time_;
+    // TODO unused?
     bool downsample_images_;
 
     ObjectPose previous_pose_;

--- a/include/trifinger_object_tracking/tricamera_object_tracking_driver.hpp
+++ b/include/trifinger_object_tracking/tricamera_object_tracking_driver.hpp
@@ -99,10 +99,7 @@ public:
 
 private:
     trifinger_cameras::TriCameraDriver camera_driver_;
-    // std::array<trifinger_cameras::PylonDriver, N_CAMERAS> cameras_;
     trifinger_object_tracking::CubeDetector cube_detector_;
-    // TODO unused?
-    bool downsample_images_;
 
     ObjectPose previous_pose_;
 };

--- a/include/trifinger_object_tracking/tricamera_object_tracking_driver.hpp
+++ b/include/trifinger_object_tracking/tricamera_object_tracking_driver.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <chrono>
+#include <filesystem>
 
 #include <robot_interfaces/sensors/sensor_driver.hpp>
 #include <trifinger_cameras/camera_parameters.hpp>
@@ -46,6 +47,23 @@ public:
         const std::string& device_id_1,
         const std::string& device_id_2,
         const std::string& device_id_3,
+        BaseCuboidModel::ConstPtr cube_model,
+        bool downsample_images = true,
+        trifinger_cameras::Settings settings = trifinger_cameras::Settings());
+
+    /**
+     * @param camera_calibration_file_1 Calibration file of first camera
+     * @param camera_calibration_file_2 likewise, the 2nd's
+     * @param camera_calibration_file_3 and the 3rd's
+     * @param cube_model The model that is used for detecting the cube.
+     * @param downsample_images If set to true (default), images are
+     *     downsampled to half their original size.
+     * @param settings Settings for the cameras.
+     */
+    TriCameraObjectTrackerDriver(
+        const std::filesystem::path& camera_calibration_file_1,
+        const std::filesystem::path& camera_calibration_file_2,
+        const std::filesystem::path& camera_calibration_file_3,
         BaseCuboidModel::ConstPtr cube_model,
         bool downsample_images = true,
         trifinger_cameras::Settings settings = trifinger_cameras::Settings());

--- a/include/trifinger_object_tracking/tricamera_object_tracking_driver.hpp
+++ b/include/trifinger_object_tracking/tricamera_object_tracking_driver.hpp
@@ -69,12 +69,13 @@ public:
         trifinger_cameras::Settings settings = trifinger_cameras::Settings());
 
     /**
-     * @brief Get the camera parameters (image size and calibration
-     * coefficients).
+     * @brief Get the camera parameters.
      *
-     * **Important:**  The calibration coefficients are only set if the driver
-     * is initialized with calibration files (see constructor).  Otherwise,
-     * they will be empty.
+     * @rst
+     * Internally, this calls
+     * :cpp:func:`trifinger_cameras::TriCameraDriver::get_sensor_info`, so see
+     * there fore more information.
+     * @endrst
      */
     trifinger_cameras::TriCameraInfo get_sensor_info() override;
 

--- a/include/trifinger_object_tracking/tricamera_object_tracking_driver.hpp
+++ b/include/trifinger_object_tracking/tricamera_object_tracking_driver.hpp
@@ -76,7 +76,7 @@ public:
      * is initialized with calibration files (see constructor).  Otherwise,
      * they will be empty.
      */
-    virtual trifinger_cameras::TriCameraInfo get_sensor_info() override;
+    trifinger_cameras::TriCameraInfo get_sensor_info() override;
 
     /**
      * @brief Get the latest observation from the three cameras.

--- a/include/trifinger_object_tracking/tricamera_object_tracking_driver.hpp
+++ b/include/trifinger_object_tracking/tricamera_object_tracking_driver.hpp
@@ -51,6 +51,16 @@ public:
         trifinger_cameras::Settings settings = trifinger_cameras::Settings());
 
     /**
+     * @brief Get the camera parameters (image size and calibration
+     * coefficients).
+     *
+     * **Important:**  The calibration coefficients are only set if the driver
+     * is initialized with calibration files (see constructor).  Otherwise,
+     * they will be empty.
+     */
+    virtual trifinger_cameras::TriCameraInfo get_sensor_info() override;
+
+    /**
      * @brief Get the latest observation from the three cameras.
      * @return TricameraObservation
      */

--- a/package.xml
+++ b/package.xml
@@ -24,6 +24,7 @@
   <depend>robot_interfaces</depend>
 
   <exec_depend>ament_index_python</exec_depend>
+  <exec_depend>signal_handler</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,5 +10,6 @@ module = [
     "cv2",
     "trifinger_cameras.*",
     "trifinger_object_tracking.*",
+    "signal_handler",
 ]
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,3 +3,12 @@ line-length = 79
 
 [tool.pylint.messages_control]
 disable = "C0330, C0326"
+
+[[tool.mypy.overrides]]
+# list all modules for which no type hints are available
+module = [
+    "cv2",
+    "trifinger_cameras.*",
+    "trifinger_object_tracking.*",
+]
+ignore_missing_imports = true

--- a/src/pybullet_tricamera_object_tracker_driver.cpp
+++ b/src/pybullet_tricamera_object_tracker_driver.cpp
@@ -29,6 +29,12 @@ PyBulletTriCameraObjectTrackerDriver::PyBulletTriCameraObjectTrackerDriver(
 {
 }
 
+trifinger_cameras::TriCameraInfo
+PyBulletTriCameraObjectTrackerDriver::get_sensor_info()
+{
+    return camera_driver_.get_sensor_info();
+}
+
 TriCameraObjectObservation
 PyBulletTriCameraObjectTrackerDriver::get_observation()
 {

--- a/src/run_on_logfile.cpp
+++ b/src/run_on_logfile.cpp
@@ -47,6 +47,7 @@ class Args : public cli_utils::ProgramOptions
 {
 public:
     std::string data_dir, debug_video_file, cube_model_name;
+    float output_fps;
 
     std::string help() const override
     {
@@ -81,6 +82,9 @@ Usage:  run_on_logfile [options] <data-dir>
             ("save-video",
              po::value<std::string>(&debug_video_file),
              "Save debug video to the specified path.")
+            ("output-fps",
+             po::value<float>(&output_fps)->default_value(10.0),
+             "Frame rate of the output video (see --save-video).")
             ;
         // clang-format on
 
@@ -138,12 +142,11 @@ int main(int argc, char **argv)
 
             if (!args.debug_video_file.empty())
             {
-                constexpr double FPS = 10.0;
                 bool ok = open_video_writer(
                     debug_video,
                     args.debug_video_file,
                     cv::VideoWriter::fourcc('X', 'V', 'I', 'D'),
-                    FPS,
+                    args.output_fps,
                     debug_img.size());
                 if (!ok)
                 {

--- a/src/tricamera_object_tracking_driver.cpp
+++ b/src/tricamera_object_tracking_driver.cpp
@@ -33,6 +33,11 @@ TriCameraObjectTrackerDriver::TriCameraObjectTrackerDriver(
 {
 }
 
+trifinger_cameras::TriCameraInfo TriCameraObjectTrackerDriver::get_sensor_info()
+{
+    return camera_driver_.get_sensor_info();
+}
+
 TriCameraObjectObservation TriCameraObjectTrackerDriver::get_observation()
 {
     std::array<cv::Mat, N_CAMERAS> images_bgr;

--- a/src/tricamera_object_tracking_driver.cpp
+++ b/src/tricamera_object_tracking_driver.cpp
@@ -22,30 +22,25 @@ TriCameraObjectTrackerDriver::TriCameraObjectTrackerDriver(
     const std::string& device_id_2,
     const std::string& device_id_3,
     BaseCuboidModel::ConstPtr cube_model,
-    bool downsample_images)
-    : cameras_{trifinger_cameras::PylonDriver(device_id_1, downsample_images),
-               trifinger_cameras::PylonDriver(device_id_2, downsample_images),
-               trifinger_cameras::PylonDriver(device_id_3, downsample_images)},
+    bool downsample_images,
+    trifinger_cameras::Settings settings)
+    : camera_driver_(
+          device_id_1, device_id_2, device_id_3, downsample_images, settings),
       cube_detector_(
           trifinger_object_tracking::create_trifingerpro_cube_detector(
               cube_model)),
-      last_update_time_(std::chrono::system_clock::now()),
       downsample_images_(downsample_images)
 {
 }
 
 TriCameraObjectObservation TriCameraObjectTrackerDriver::get_observation()
 {
-    last_update_time_ += this->rate;
-    std::this_thread::sleep_until(last_update_time_);
-
     std::array<cv::Mat, N_CAMERAS> images_bgr;
-    TriCameraObjectObservation observation;
+
+    TriCameraObjectObservation observation = camera_driver_.get_observation();
 
     for (size_t i = 0; i < N_CAMERAS; i++)
     {
-        observation.cameras[i] = cameras_[i].get_observation();
-
         cv::cvtColor(
             observation.cameras[i].image, images_bgr[i], cv::COLOR_BayerBG2BGR);
     }

--- a/src/tricamera_object_tracking_driver.cpp
+++ b/src/tricamera_object_tracking_driver.cpp
@@ -33,6 +33,26 @@ TriCameraObjectTrackerDriver::TriCameraObjectTrackerDriver(
 {
 }
 
+TriCameraObjectTrackerDriver::TriCameraObjectTrackerDriver(
+    const std::filesystem::path& camera_calibration_file_1,
+    const std::filesystem::path& camera_calibration_file_2,
+    const std::filesystem::path& camera_calibration_file_3,
+    BaseCuboidModel::ConstPtr cube_model,
+    bool downsample_images,
+    trifinger_cameras::Settings settings)
+    : camera_driver_(camera_calibration_file_1,
+                     camera_calibration_file_2,
+                     camera_calibration_file_3,
+                     downsample_images,
+                     settings),
+      cube_detector_(
+          trifinger_object_tracking::create_trifingerpro_cube_detector(
+              cube_model)),
+      downsample_images_(downsample_images)
+
+{
+}
+
 trifinger_cameras::TriCameraInfo TriCameraObjectTrackerDriver::get_sensor_info()
 {
     return camera_driver_.get_sensor_info();

--- a/src/tricamera_object_tracking_driver.cpp
+++ b/src/tricamera_object_tracking_driver.cpp
@@ -28,8 +28,7 @@ TriCameraObjectTrackerDriver::TriCameraObjectTrackerDriver(
           device_id_1, device_id_2, device_id_3, downsample_images, settings),
       cube_detector_(
           trifinger_object_tracking::create_trifingerpro_cube_detector(
-              cube_model)),
-      downsample_images_(downsample_images)
+              cube_model))
 {
 }
 
@@ -47,9 +46,7 @@ TriCameraObjectTrackerDriver::TriCameraObjectTrackerDriver(
                      settings),
       cube_detector_(
           trifinger_object_tracking::create_trifingerpro_cube_detector(
-              cube_model)),
-      downsample_images_(downsample_images)
-
+              cube_model))
 {
 }
 

--- a/srcpy/py_tricamera_types.cpp
+++ b/srcpy/py_tricamera_types.cpp
@@ -58,7 +58,8 @@ PYBIND11_MODULE(py_tricamera_types, m)
 #ifdef Pylon_FOUND
     pybind11::class_<TriCameraObjectTrackerDriver,
                      std::shared_ptr<TriCameraObjectTrackerDriver>,
-                     SensorDriver<TriCameraObjectObservation>>(
+                     SensorDriver<TriCameraObjectObservation,
+                                  trifinger_cameras::TriCameraInfo>>(
         m, "TriCameraObjectTrackerDriver")
         .def(pybind11::init<const std::string&,
                             const std::string&,

--- a/srcpy/py_tricamera_types.cpp
+++ b/srcpy/py_tricamera_types.cpp
@@ -71,6 +71,16 @@ PYBIND11_MODULE(py_tricamera_types, m)
              pybind11::arg("camera3"),
              pybind11::arg("cube_model"),
              pybind11::arg("downsample_images") = true)
+        .def(pybind11::init<const std::filesystem::path&,
+                            const std::filesystem::path&,
+                            const std::filesystem::path&,
+                            BaseCuboidModel::ConstPtr,
+                            bool>(),
+             pybind11::arg("camera_calibration_file_1"),
+             pybind11::arg("camera_calibration_file_2"),
+             pybind11::arg("camera_calibration_file_3"),
+             pybind11::arg("cube_model"),
+             pybind11::arg("downsample_images") = true)
         .def("get_observation",
              &TriCameraObjectTrackerDriver::get_observation,
              "Get the latest observation from the three cameras.")

--- a/srcpy/py_tricamera_types.cpp
+++ b/srcpy/py_tricamera_types.cpp
@@ -31,7 +31,8 @@ PYBIND11_MODULE(py_tricamera_types, m)
     // import for Python bindings of ObjectPose
     pybind11::module::import("trifinger_object_tracking.py_object_tracker");
 
-    create_sensor_bindings<TriCameraObjectObservation>(m);
+    create_sensor_bindings<TriCameraObjectObservation,
+                           trifinger_cameras::TriCameraInfo>(m);
 
     pybind11::class_<TriCameraObjectObservation,
                      trifinger_cameras::TriCameraObservation>(
@@ -92,7 +93,8 @@ PYBIND11_MODULE(py_tricamera_types, m)
 
     pybind11::class_<PyBulletTriCameraObjectTrackerDriver,
                      std::shared_ptr<PyBulletTriCameraObjectTrackerDriver>,
-                     SensorDriver<TriCameraObjectObservation>>(
+                     SensorDriver<TriCameraObjectObservation,
+                                  trifinger_cameras::TriCameraInfo>>(
         m, "PyBulletTriCameraObjectTrackerDriver")
         .def(pybind11::init<pybind11::object,
                             robot_interfaces::TriFingerTypes::BaseDataPtr,

--- a/srcpy/py_tricamera_types.cpp
+++ b/srcpy/py_tricamera_types.cpp
@@ -9,6 +9,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <pybind11/stl_bind.h>
+#include <pybind11/stl/filesystem.h>
 
 #include <pybind11_opencv/cvbind.hpp>
 #include <trifinger_object_tracking/pybullet_tricamera_object_tracker_driver.hpp>

--- a/srcpy/py_tricamera_types.cpp
+++ b/srcpy/py_tricamera_types.cpp
@@ -8,8 +8,8 @@
 #include <pybind11/embed.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
-#include <pybind11/stl_bind.h>
 #include <pybind11/stl/filesystem.h>
+#include <pybind11/stl_bind.h>
 
 #include <pybind11_opencv/cvbind.hpp>
 #include <trifinger_object_tracking/pybullet_tricamera_object_tracker_driver.hpp>

--- a/srcpy/py_tricamera_types.cpp
+++ b/srcpy/py_tricamera_types.cpp
@@ -33,7 +33,8 @@ PYBIND11_MODULE(py_tricamera_types, m)
 
     create_sensor_bindings<TriCameraObjectObservation>(m);
 
-    pybind11::class_<TriCameraObjectObservation>(
+    pybind11::class_<TriCameraObjectObservation,
+                     trifinger_cameras::TriCameraObservation>(
         m,
         "TriCameraObjectObservation",
         "Observation from the three cameras, including the estimated object "

--- a/test/test_lightblue_segmenter.py
+++ b/test/test_lightblue_segmenter.py
@@ -1,4 +1,5 @@
 """Test the "lightblue segmenter" via its Python bindings."""
+
 import os
 import pathlib
 


### PR DESCRIPTION
## Description

### Refactor to reduce redundancy with trifinger_cameras

- `TriCameraObjectObservation` now inherits from `trifinger_cameras::TriCameraObservation`.  Apart from removing redundant field definitions, this might actually also allow for functions that can use both types (but I didn't explore that option yet).
- Driver classes now use an instance of their corresponding trifinger_cameras-counterpart internally to reduce redundancy.

### Implement `get_sensor_info` in driver classes

Simply forwards the calls to the internal trifinger_cameras drivers.  There is no additional information about the object tracking included.
For this, also add a constructor that accepts calibration parameter files instead of just the camera name (like done in trifinger_cameras).


### Other changes
- Add `--backend-only` mode to `demo_cameras`.  This makes it easy to run a object tracker camera backend for testing.  Actually this script is slowly evolving into something that exceeds being just a demo...
  Also renamed `--multi-process` to `--frontend-only` for consistency.
- In the documentation, link to trifinger_cameras instead of duplicating texts.
- Add option --output-fps to run_on_logfile.  This allows to adjust the frame rate of the saved video.  Mostly needed in case the data was recorded at a different rate than the default 10Hz. Ideally, this information should be stored in the camera_data file, but for now this option has to suffice.

## How I Tested
Tested with the demo scripts.