### PR TITLE
Run on HDF5 log files and add tool to find ground truth poses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   driver classes which accept camera info files instead of device IDs.
 - Add a "backend-only" mode to `demo_cameras`.  Use this if the front end is running in
   a separate process.
+- Add executable `run_on_tricamera_hdf5` to run the object pose estimation on a HDF5 log
+  file.
+- Add some helper methods to `ObjectPose` to more easily convert to/from other
+  representations of poses.
+- Add executable `manual_annotation_hdf5` to manually find the correct pose for a given
+  frame in a HDF5 logfile.
 
 ### Removed
 - The `ProgramOptions` class has been moved to its own package

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,6 +289,7 @@ install_scripts(
     scripts/get_xgb_dump.py
     scripts/plot_log_timestamps.py
     scripts/record_debug_images.py
+    scripts/run_on_tricamera_hdf5.py
     scripts/train_xgb_tree.py
     scripts/tricamera_log_analyzer.py
     scripts/tricamera_log_converter.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ find_package(LAPACK REQUIRED)
 find_package(BLAS REQUIRED)
 find_package(OpenCV REQUIRED)
 find_package(Armadillo REQUIRED)
+find_package(fmt REQUIRED)
 
 
 if (${HAS_PYLON_DRIVERS})
@@ -243,6 +244,18 @@ target_link_libraries(benchmark_with_logfile
 )
 
 
+add_executable(manual_annotation_hdf5 src/manual_annotation_hdf5.cpp)
+target_include_directories(manual_annotation_hdf5 PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+target_link_libraries(manual_annotation_hdf5
+    fmt::fmt
+    cube_detector
+    cube_visualizer
+)
+
+
 add_executable(demo_lightblue_segmenter_cpp demos/demo_lightblue_segmenter.cpp)
 target_include_directories(demo_lightblue_segmenter_cpp PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -273,6 +286,7 @@ install(
         single_observation
         run_on_logfile
         benchmark_with_logfile
+        manual_annotation_hdf5
         demo_lightblue_segmenter_cpp
 
     EXPORT export_${PROJECT_NAME}

--- a/include/trifinger_object_tracking/cube_visualizer.hpp
+++ b/include/trifinger_object_tracking/cube_visualizer.hpp
@@ -97,9 +97,16 @@ public:
     std::vector<std::vector<cv::Point2f>> get_projected_points(
         const ObjectPose &object_pose);
 
+    //! Set line thickness for wireframe cube
+    void set_line_thickness(int line_thickness)
+    {
+        line_thickness_ = line_thickness;
+    }
+
 private:
     BaseCuboidModel::ConstPtr cube_model_;
     PoseDetector pose_detector_;
+    int line_thickness_ = 2;
 
     //! Draw cube with filled faces in the given image
     void draw_filled_cube(cv::Mat &image,

--- a/include/trifinger_object_tracking/cube_visualizer.hpp
+++ b/include/trifinger_object_tracking/cube_visualizer.hpp
@@ -93,13 +93,13 @@ public:
         float opacity = 0.5,
         float scale = 1.0);
 
-private:
-    BaseCuboidModel::ConstPtr cube_model_;
-    PoseDetector pose_detector_;
-
     //! Get projected corner points for the given object pose.
     std::vector<std::vector<cv::Point2f>> get_projected_points(
         const ObjectPose &object_pose);
+
+private:
+    BaseCuboidModel::ConstPtr cube_model_;
+    PoseDetector pose_detector_;
 
     //! Draw cube with filled faces in the given image
     void draw_filled_cube(cv::Mat &image,

--- a/include/trifinger_object_tracking/object_pose.hpp
+++ b/include/trifinger_object_tracking/object_pose.hpp
@@ -21,6 +21,34 @@ public:
     //! Confidence of the accuracy of the given pose.  Ranges from 0 to 1.
     double confidence = 0.0;
 
+    ObjectPose() = default;
+
+    // construct pose from a homogeneous 4x4 transformation matrix
+    ObjectPose(const Eigen::Matrix4d& matrix, double confidence = 0.0)
+        : confidence(confidence)
+    {
+        position = matrix.block<3, 1>(0, 3);
+        Eigen::Quaterniond q(matrix.block<3, 3>(0, 0));
+        orientation[0] = q.x();
+        orientation[1] = q.y();
+        orientation[2] = q.z();
+        orientation[3] = q.w();
+    }
+
+    //! Get the orientation as Eigen::Quaterniond.
+    Eigen::Quaterniond quaternion() const
+    {
+        constexpr int X = 0, Y = 1, Z = 2, W = 3;
+        return Eigen::Quaterniond(
+            orientation[W], orientation[X], orientation[Y], orientation[Z]);
+    }
+
+    //! Get the pose as Eigen::Affine3d.
+    Eigen::Affine3d affine() const
+    {
+        return Eigen::Translation3d(position) * quaternion();
+    }
+
     //! For serialization with cereal.
     template <class Archive>
     void serialize(Archive& archive)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ disable = "C0330, C0326"
 # list all modules for which no type hints are available
 module = [
     "cv2",
+    "h5py",
     "trifinger_cameras.*",
     "trifinger_object_tracking.*",
     "signal_handler",

--- a/scripts/run_on_tricamera_hdf5.py
+++ b/scripts/run_on_tricamera_hdf5.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Run object tracker on a TriCamera HDF5 log file."""
+
+import argparse
+import pathlib
+import sys
+import json
+import time
+import statistics
+
+import cv2
+import h5py
+
+import trifinger_object_tracking.py_object_tracker as object_tracker
+from trifinger_cameras import hdf5, CAMERA_NAMES
+from trifinger_cameras.py_camera_types import CameraParameters
+
+
+def construct_camera_parameters(
+    h5file: h5py.File, camera_name: str
+) -> CameraParameters:
+    """Construct CameraParameters from data in HDF5 file.
+
+    Args:
+        h5file: Opened HDF5 file.
+        camera_name: Name of the camera.
+
+    Returns:
+        Camera parameters of the specified camera.
+    """
+    h5_camera_info = h5file["camera_info"][camera_name]
+
+    params = CameraParameters()
+    params.image_width = h5file.attrs["image_width"]
+    params.image_height = h5file.attrs["image_height"]
+    params.camera_matrix = h5_camera_info["camera_matrix"][:]
+    params.distortion_coefficients = h5_camera_info["distortion_coefficients"][
+        :
+    ]
+    params.tf_world_to_camera = h5_camera_info["tf_world_to_camera"][:]
+    return params
+
+
+def main() -> None:
+    """Entry point."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "logfile",
+        type=pathlib.Path,
+        help="Path to the HDF5 log file.",
+    )
+    parser.add_argument(
+        "--no-visualization",
+        action="store_true",
+        help="Disable displaying visualization images.",
+    )
+    parser.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        help="Disable printing pose information.",
+    )
+    parser.add_argument(
+        "--summary",
+        action="store_true",
+        help="Show timing statistics at the end.",
+    )
+    args = parser.parse_args()
+
+    if not args.logfile.is_file():
+        print(f"{args.logfile} does not exist.")
+        sys.exit(1)
+
+    # Open HDF5 file
+    with h5py.File(args.logfile, "r") as h5file:
+        try:
+            hdf5.verify_tricamera_hdf5(h5file, supported_formats=(2,))
+        except ValueError as e:
+            print(e, file=sys.stderr)
+            sys.exit(1)
+
+        # Create cube detector with calibration parameters
+        camera_params = [
+            construct_camera_parameters(h5file, camera_name)
+            for camera_name in CAMERA_NAMES
+        ]
+        cube_model = object_tracker.CubeV2Model()
+        cube_detector = object_tracker.CubeDetector(cube_model, camera_params)
+
+        # Get images from HDF5
+        n_frames = h5file["images"].shape[0]
+        detection_times_ms = []
+        for frame_idx in range(n_frames):
+            # Get images for all three cameras
+            images = [
+                utils.convert_image(h5file["images"][frame_idx, i])
+                for i in range(len(CAMERA_NAMES))
+            ]
+
+            start_time = time.monotonic()
+            pose = cube_detector.detect_cube_single_thread(images)
+            detection_time_ms = (time.monotonic() - start_time) * 1000
+            detection_times_ms.append(detection_time_ms)
+
+            if not args.quiet:
+                pose_data = {
+                    "position": pose.position.tolist(),
+                    "orientation": pose.orientation.tolist(),
+                    "confidence": pose.confidence,
+                    "duration_ms": detection_time_ms,
+                }
+                print(json.dumps(pose_data))
+
+            if not args.no_visualization:
+                debug_img = cube_detector.create_debug_image()
+                cv2.imshow("Debug", debug_img)
+                # stop if either "q" or ESC is pressed
+                if cv2.waitKey(3) in [ord("q"), 27]:  # 27 = ESC
+                    break
+
+        if args.summary:
+            mean_time = statistics.mean(detection_times_ms)
+            std_time = statistics.stdev(detection_times_ms)
+            print(
+                "\nTiming Summary:",
+                f"\n  Mean detection time: {mean_time:.0f} ms",
+                f"\n  Std dev: {std_time:.0f} ms",
+                f"\n  Total frames: {len(detection_times_ms)}",
+                file=sys.stderr,
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cube_visualizer.cpp
+++ b/src/cube_visualizer.cpp
@@ -99,7 +99,7 @@ void CubeVisualizer::draw_cube_wireframe(
                  imgpoints[it.second.c1],
                  imgpoints[it.second.c2],
                  cv::Scalar(100, 50, 0),
-                 2);
+                 line_thickness_);
     }
 
     // over-draw with the visible edges in a brighter colour
@@ -114,7 +114,7 @@ void CubeVisualizer::draw_cube_wireframe(
                      imgpoints[corner_indices[ci]],
                      imgpoints[corner_indices[(ci + 1) % 4]],
                      cv::Scalar(255, 100, 0),
-                     2);
+                     line_thickness_);
         }
     }
 }
@@ -122,8 +122,6 @@ void CubeVisualizer::draw_cube_wireframe(
 std::vector<std::vector<cv::Point2f>> CubeVisualizer::get_projected_points(
     const ObjectPose &object_pose)
 {
-    std::array<cv::Mat, CubeVisualizer::N_CAMERAS> out_images;
-
     cv::Vec3d position, rotvec;
     cv::eigen2cv(object_pose.position, position);
 

--- a/src/manual_annotation_hdf5.cpp
+++ b/src/manual_annotation_hdf5.cpp
@@ -1,0 +1,398 @@
+/**
+ * @file
+ * @brief Manual find ground truth pose for a TriCamera HDF5 file.
+ */
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+
+#include <fmt/format.h>
+#include <Eigen/Eigen>
+#include <opencv2/core/eigen.hpp>
+#include <opencv2/core/utility.hpp>
+#include <opencv2/hdf.hpp>
+#include <opencv2/videoio.hpp>
+
+#include <trifinger_object_tracking/cube_detector.hpp>
+#include <trifinger_object_tracking/cube_model.hpp>
+#include <trifinger_object_tracking/cube_visualizer.hpp>
+
+constexpr int N_CAMERAS = 3;
+
+void zoom_to_object(std::array<cv::Mat, N_CAMERAS> &images,
+                    const std::vector<std::vector<cv::Point2f>> &object_points)
+{
+    constexpr int padding = 15;
+
+    for (size_t i = 0; i < N_CAMERAS; ++i)
+    {
+        cv::Rect boundingbox = cv::boundingRect(object_points[i]);
+        boundingbox.x -= padding;
+        boundingbox.y -= padding;
+        boundingbox.height += 2 * padding;
+        boundingbox.width += 2 * padding;
+
+        cv::Size orig_size = images[i].size();
+
+        // cut out the bounding box area with the given padding
+        images[i] = images[i](boundingbox);
+
+        // scale back to original size
+        cv::resize(images[i], images[i], orig_size);
+    }
+}
+
+int main(int argc, char *argv[])
+{
+    const cv::String keys =
+        "{@camera_info_60 | <none> | Camera parameter file for camera60 }"
+        "{@camera_info_180 | <none> | Camera parameter file for camera180 }"
+        "{@camera_info_300 | <none> | Camera parameter file for camera300 }"
+        "{@object_model | <none> | Name of the object model to use }"
+        "{@hdf5_file | <none> | HDF5 file with TriCamera data }"
+        "{frame | 0 | Frame number }"
+        "{help h | | print this message }";
+    cv::CommandLineParser parser(argc, argv, keys);
+    parser.about(
+        "Manual find ground truth object pose for a TriCamera HDF5 file");
+    if (parser.has("help"))
+    {
+        parser.printMessage();
+        return 0;
+    }
+    cv::String camera_info_60 = parser.get<cv::String>(0);
+    cv::String camera_info_180 = parser.get<cv::String>(1);
+    cv::String camera_info_300 = parser.get<cv::String>(2);
+    cv::String object_model_name = parser.get<cv::String>(3);
+    cv::String hdf5_file = parser.get<cv::String>(4);
+    int frame_number = parser.get<int>("frame");
+
+    if (!parser.check())
+    {
+        parser.printErrors();
+        return 0;
+    }
+
+    if (!std::filesystem::exists(hdf5_file))
+    {
+        fmt::print(stderr, "File {} does not exist\n", hdf5_file);
+        return 1;
+    }
+
+    cv::Ptr<cv::hdf::HDF5> h5io = cv::hdf::open(hdf5_file);
+
+    // validate the file
+    cv::String attr_magic_name = "magic";
+    int magic_byte = 0;
+    if (!h5io->atexists(attr_magic_name))
+    {
+        fmt::print(
+            stderr,
+            "Input file doesn't seem to be a TriCamera log file (no magic "
+            "byte)\n");
+        return 1;
+    }
+    h5io->atread(&magic_byte, attr_magic_name);
+    if (magic_byte != 0x3CDA7A00)
+    {
+        fmt::print(
+            stderr,
+            "Input file doesn't seem to be a TriCamera log file (bad magic "
+            "byte)\n");
+        return 1;
+    }
+
+    cv::String attr_formatversion_name = "format_version";
+    int format_version = 0;
+    h5io->atread(&format_version, attr_formatversion_name);
+    if (format_version != 1 and format_version != 2)
+    {
+        fmt::print(stderr,
+                   "Unsupported file format version {}.  Supported versions "
+                   "are 1-2.\n",
+                   format_version);
+        return 1;
+    }
+
+    auto object_model =
+        trifinger_object_tracking::get_model_by_name(object_model_name);
+    trifinger_object_tracking::CubeDetector cube_detector(object_model,
+                                                          {
+                                                              camera_info_60,
+                                                              camera_info_180,
+                                                              camera_info_300,
+                                                          });
+    trifinger_object_tracking::CubeVisualizer visualizer(object_model,
+                                                         {
+                                                             camera_info_60,
+                                                             camera_info_180,
+                                                             camera_info_300,
+                                                         });
+    visualizer.set_line_thickness(1);
+
+    int image_width, image_height;
+    h5io->atread(&image_width, "image_width");
+    h5io->atread(&image_height, "image_height");
+
+    int n_images = h5io->dsgetsize("images")[0];
+    int n_views = h5io->dsgetsize("images")[1];
+
+    if (n_views != N_CAMERAS)
+    {
+        fmt::print(stderr,
+                   "Input file doesn't seem to be a TriCamera log file (wrong "
+                   "number of views)\n");
+        return 1;
+    }
+
+    if (frame_number < 0 || frame_number >= n_images)
+    {
+        fmt::print(stderr,
+                   "Frame number must be between 0 and {} (inclusive)\n",
+                   n_images - 1);
+        return 1;
+    }
+
+    std::array<cv::Mat, N_CAMERAS> images;
+    for (int j = 0; j < N_CAMERAS; j++)
+    {
+        cv::Mat image;
+
+        // Set offset and counts to read only the image of frame i/camera j
+        int offset[4] = {frame_number, j, 0, 0};
+        int counts[4] = {1, 1, image_height, image_width};
+        h5io->dsread(image, "images", offset, counts);
+
+        // Image is now of shape (1, 1, height, width).  Reshape to get rid
+        // of the first two dimensions.
+        image = image.reshape(1, image_height);
+
+        // Images in the HDF5 file are raw Bayer images.  Convert to BGR.
+        cv::cvtColor(image, image, cv::COLOR_BayerBG2BGR);
+
+        images[j] = image;
+    }
+
+    float angle120 = 2 * M_PI / 3;
+    std::array<cv::Affine3d, 3> view_transforms{
+        // camera60
+        cv::Affine3d(cv::Affine3d::Mat3(std::cos(-angle120),
+                                        -std::sin(-angle120),
+                                        0,
+                                        std::sin(-angle120),
+                                        std::cos(-angle120),
+                                        0,
+                                        0,
+                                        0,
+                                        1)),
+        // camera180
+        cv::Affine3d::Identity(),
+        // camera300
+        cv::Affine3d(cv::Affine3d::Mat3(std::cos(angle120),
+                                        -std::sin(angle120),
+                                        0,
+                                        std::sin(angle120),
+                                        std::cos(angle120),
+                                        0,
+                                        0,
+                                        0,
+                                        1))};
+
+    size_t active_view = 1;
+    constexpr float position_step_size = 0.0005;
+    constexpr float rotation_step_size = 0.01;
+    bool zoom = false;
+    bool fill_faces = true;
+
+    // get initial pose estimate
+    trifinger_object_tracking::ObjectPose pose =
+        cube_detector.detect_cube_single_thread(images);
+
+    // convert pose to cv::Affine3d
+    Eigen::Matrix4d pose_matrix = pose.affine().matrix();
+    cv::Mat pose_matrix_cv;
+    cv::eigen2cv(pose_matrix, pose_matrix_cv);
+    cv::Affine3d pose_cv(pose_matrix_cv);
+
+    fmt::print(
+        "=====================================\n"
+        "Instructions:\n"
+        "      q:  quit\n"
+        "      z:  toggle zoom\n"
+        "      c:  toggle face colour\n"
+        "      x:  set pose to centre of arena\n"
+        "  1/2/3:  select camera60/180/300\n"
+        "    w/s:  move up/down\n"
+        "    a/d:  move left/right\n"
+        "    r/f:  move forward\n"
+        "    i/k:  rotate up/down\n"
+        "    j/l:  rotate left/right\n"
+        "    u/o:  rotate around z-axis\n"
+        "      p:  print current pose\n"
+        "      g:  save current pose to ground\n"
+        "          truth file\n"
+        "=====================================\n");
+
+    while (true)
+    {
+        // convert pose_cv back to ObjectPose for visualization
+        cv::cv2eigen(pose_cv.matrix, pose_matrix);
+        pose = trifinger_object_tracking::ObjectPose(pose_matrix);
+
+        float alpha = fill_faces ? 0.4 : 0.9;
+        std::array<cv::Mat, N_CAMERAS> visualization_images =
+            visualizer.draw_cube(images, pose, fill_faces, alpha);
+
+        if (zoom)
+        {
+            zoom_to_object(visualization_images,
+                           visualizer.get_projected_points(pose));
+        }
+
+        // mark active view
+        cv::line(visualization_images[active_view],
+                 cv::Point(0, 0),
+                 cv::Point(visualization_images[active_view].cols, 0),
+                 cv::Scalar(0, 200, 0),
+                 10);
+
+        // combine all images horizontally into one output image
+        cv::Mat viz;
+        cv::hconcat(visualization_images, viz);
+
+        cv::Affine3d transform = cv::Affine3d::Identity();
+
+        cv::imshow("Estimated Pose", viz);
+        int key = cv::waitKey(0);
+        if (key == 'q')
+        {
+            break;
+        }
+        else if (key == 'z')
+        {
+            zoom = !zoom;
+        }
+        else if (key == 'c')
+        {
+            fill_faces = !fill_faces;
+        }
+        else if (key == 'x')
+        {
+            // TODO: the z value is specific for the 65mm cube, so not very
+            // generic here...
+            pose_cv.translation(cv::Vec3d(0, 0, 0.0325));
+            pose_cv.rotation(cv::Vec3d(0, 0, 0));
+        }
+        else if (key == ' ')
+        {
+            pose_cv = cv::Affine3d::Identity();
+        }
+        else if (key == '1')
+        {
+            active_view = 0;
+        }
+        else if (key == '2')
+        {
+            active_view = 1;
+        }
+        else if (key == '3')
+        {
+            active_view = 2;
+        }
+        else if (key == 'w')
+        {
+            transform.translation(cv::Vec3d(0, position_step_size, 0));
+        }
+        else if (key == 's')
+        {
+            transform.translation(cv::Vec3d(0, -position_step_size, 0));
+        }
+        else if (key == 'a')
+        {
+            transform.translation(cv::Vec3d(-position_step_size, 0, 0));
+        }
+        else if (key == 'd')
+        {
+            transform.translation(cv::Vec3d(position_step_size, 0, 0));
+        }
+        else if (key == 'r')
+        {
+            transform.translation(cv::Vec3d(0, 0, position_step_size));
+        }
+        else if (key == 'f')
+        {
+            transform.translation(cv::Vec3d(0, 0, -position_step_size));
+        }
+        else if (key == 'i')
+        {
+            transform.rotation(cv::Vec3d(-rotation_step_size, 0, 0));
+        }
+        else if (key == 'k')
+        {
+            transform.rotation(cv::Vec3d(rotation_step_size, 0, 0));
+        }
+        else if (key == 'j')
+        {
+            transform.rotation(cv::Vec3d(0, -rotation_step_size, 0));
+        }
+        else if (key == 'l')
+        {
+            transform.rotation(cv::Vec3d(0, rotation_step_size, 0));
+        }
+        else if (key == 'u')
+        {
+            transform.rotation(cv::Vec3d(0, 0, rotation_step_size));
+        }
+        else if (key == 'o')
+        {
+            transform.rotation(cv::Vec3d(0, 0, -rotation_step_size));
+        }
+        else if (key == 'p')
+        {
+            std::cout << "Pose (matrix):\n"
+                      << pose_cv.matrix << std::endl
+                      << std::endl;
+
+            std::cout << "{\"translation\": " << pose_cv.translation()
+                      << ", \"rotation\": " << pose_cv.rvec() << "}"
+                      << std::endl;
+        }
+        else if (key == 'g')
+        {
+            std::filesystem::path hdf5_path(hdf5_file);
+            std::filesystem::path ground_truth_file(hdf5_path);
+            ground_truth_file.replace_extension("ground_truth.json");
+
+            std::ofstream ground_truth_stream(ground_truth_file);
+            if (!ground_truth_stream.is_open())
+            {
+                fmt::print(
+                    stderr, "Failed to open {}\n", ground_truth_file.string());
+                return 1;
+            }
+
+            ground_truth_stream
+                << "{\"pose\": " << cv::Mat(pose_cv.matrix).reshape(1, 1) << "}"
+                << std::endl;
+            ground_truth_stream.close();
+
+            fmt::print("Ground truth saved to {}\n",
+                       ground_truth_file.string());
+        }
+
+        // operation space is using the rotation of view_transforms and shifts
+        // the origin to the center of the object pose (so the object rotates
+        // around its centre)
+        cv::Affine3d operation_space = view_transforms[active_view];
+        operation_space.translation(
+            -(view_transforms[active_view] * pose_cv).translation());
+
+        // transform pose to space of active view, apply user transform and then
+        // transform back to world space
+        pose_cv = operation_space.inv() * transform * operation_space * pose_cv;
+    }
+
+    h5io->close();
+
+    return 0;
+}

--- a/srcpy/py_object_tracker.cpp
+++ b/srcpy/py_object_tracker.cpp
@@ -10,6 +10,7 @@
 
 #include <pybind11_opencv/cvbind.hpp>
 
+#include <trifinger_cameras/camera_parameters.hpp>
 #include <trifinger_object_tracking/cube_detector.hpp>
 #include <trifinger_object_tracking/cube_model.hpp>
 #include <trifinger_object_tracking/fake_object_tracker_backend.hpp>
@@ -121,6 +122,12 @@ PYBIND11_MODULE(py_object_tracker, m)
         .def(pybind11::init<
              BaseCuboidModel::ConstPtr,
              const std::array<std::string, CubeDetector::N_CAMERAS>>())
+        .def(
+            pybind11::init<BaseCuboidModel::ConstPtr,
+                           const std::array<trifinger_cameras::CameraParameters,
+                                            CubeDetector::N_CAMERAS>&>(),
+            "model"_a,
+            "camera_parameters"_a)
         .def("detect_cube_single_thread",
              &CubeDetector::detect_cube_single_thread,
              pybind11::call_guard<pybind11::gil_scoped_release>())


### PR DESCRIPTION
## Description

Several changes, all related to better/easier evaluation of pose estimation accuracy:

- Add script `run_on_tricamera_hdf5` to run pose estimation on HDF5 log files (see https://github.com/open-dynamic-robot-initiative/trifinger_cameras/pull/49).
- Add executable `manual_annotation_hdf5` to manually find the ground truth pose for a frame in a HDF5 log.  It shows the frame, runs pose estimation once, for an initial guess, and then let's the user refine the pose using keyboard commands.
- Some other small change, related to the points above (adding some helper methods, etc.)


## How I Tested

By running the new executables.