### PR TITLE
fix: Add missing include

### DIFF
--- a/include/trifinger_object_tracking/cube_model.hpp
+++ b/include/trifinger_object_tracking/cube_model.hpp
@@ -5,6 +5,7 @@
  */
 #pragma once
 
+#include <array>
 #include <cstdint>
 #include <map>
 #include <memory>


### PR DESCRIPTION
This was fine in the past but seems that with newer versions of gcc the missing include was causing an error (discovered during an ongoing attempt to port to Ubuntu 24.04).
