### PR TITLE
Downsample images in the driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   this package and the one from cli_utils is used instead.
 - Option `--multi-process` from `demo_cameras`.  Use `--frontend-only` instead.
 
+### Changed
+- In `TriCameraObjectTrackerDriver`: Set the internal camera driver to provide
+  full-resolution images an do the downsampling to half-size here.  This is needed as
+  the downsampling feature has been removed from `trifinger_cameras`.  This is just an
+  implementation detail of the interplay of this package with `trifinger_cameras` and
+  should not change the actual behaviour.
+
 ### Fixed
 - pybind11 build error on Ubuntu 22.04
 

--- a/include/trifinger_object_tracking/cube_detector.hpp
+++ b/include/trifinger_object_tracking/cube_detector.hpp
@@ -74,8 +74,10 @@ private:
  * a CubeDetector instance for it.
  *
  * @param cube_model The model that is used for detecting the cube.
+ * @param downsample_images If set to true (default), images are
+ *     downsampled to half their original size for object tracking.
  */
 CubeDetector create_trifingerpro_cube_detector(
-    BaseCuboidModel::ConstPtr cube_model);
+    BaseCuboidModel::ConstPtr cube_model, bool downsample_images = true);
 
 }  // namespace trifinger_object_tracking

--- a/include/trifinger_object_tracking/tricamera_object_tracking_driver.hpp
+++ b/include/trifinger_object_tracking/tricamera_object_tracking_driver.hpp
@@ -40,7 +40,7 @@ public:
      * @param device_id_3 and the 3rd's
      * @param cube_model The model that is used for detecting the cube.
      * @param downsample_images If set to true (default), images are
-     *     downsampled to half their original size.
+     *     downsampled to half their original size for object tracking.
      * @param settings Settings for the cameras.
      */
     TriCameraObjectTrackerDriver(
@@ -57,7 +57,7 @@ public:
      * @param camera_calibration_file_3 and the 3rd's
      * @param cube_model The model that is used for detecting the cube.
      * @param downsample_images If set to true (default), images are
-     *     downsampled to half their original size.
+     *     downsampled to half their original size for object tracking.
      * @param settings Settings for the cameras.
      */
     TriCameraObjectTrackerDriver(
@@ -99,6 +99,7 @@ public:
     cv::Mat get_debug_image(bool fill_faces = false);
 
 private:
+    bool downsample_images_ = true;
     trifinger_cameras::TriCameraDriver camera_driver_;
     trifinger_object_tracking::CubeDetector cube_detector_;
 

--- a/src/cube_detector.cpp
+++ b/src/cube_detector.cpp
@@ -223,15 +223,27 @@ ObjectPose CubeDetector::convert_pose(const Pose &pose)
 }
 
 CubeDetector create_trifingerpro_cube_detector(
-    BaseCuboidModel::ConstPtr cube_model)
+    BaseCuboidModel::ConstPtr cube_model, bool downsample_images)
 {
-    return CubeDetector(
-        cube_model,
-        {
-            "/etc/trifingerpro/camera60_cropped_and_downsampled.yml",
-            "/etc/trifingerpro/camera180_cropped_and_downsampled.yml",
-            "/etc/trifingerpro/camera300_cropped_and_downsampled.yml",
-        });
+    if (downsample_images)
+    {
+        return CubeDetector(
+            cube_model,
+            {
+                "/etc/trifingerpro/camera60_cropped_and_downsampled.yml",
+                "/etc/trifingerpro/camera180_cropped_and_downsampled.yml",
+                "/etc/trifingerpro/camera300_cropped_and_downsampled.yml",
+            });
+    }
+    else
+    {
+        return CubeDetector(cube_model,
+                            {
+                                "/etc/trifingerpro/camera60_cropped.yml",
+                                "/etc/trifingerpro/camera180_cropped.yml",
+                                "/etc/trifingerpro/camera300_cropped.yml",
+                            });
+    }
 }
 
 }  // namespace trifinger_object_tracking

--- a/srcpy/py_object_tracker.cpp
+++ b/srcpy/py_object_tracker.cpp
@@ -148,5 +148,7 @@ PYBIND11_MODULE(py_object_tracker, m)
           &create_trifingerpro_cube_detector,
           "Create a CubeDetector for TriFingerPro robot, automatically loading "
           "the local camera calibration.",
+          "cube_model"_a,
+          "downsample_images"_a = true,
           pybind11::call_guard<pybind11::gil_scoped_release>());
 }


### PR DESCRIPTION

## Description
With a recent change (https://github.com/open-dynamic-robot-initiative/trifinger_cameras/pull/53), trifinger_cameras::TriCameraDriver does not support downsampling the images internally anymore.  Hence, the images need to be downsampled here (based on the flag), to keep the old behaviour of the object tracker.
