### PR TITLE
Add `has_pose` flag to object pose in HDF5 data

### DIFF
--- a/doc/hdf5_log_files.rst
+++ b/doc/hdf5_log_files.rst
@@ -9,6 +9,9 @@ portable HDF5 format.
 The data format is the same as described in :doc:`trifinger_cameras:doc/hdf5_log_files`
 but extended by the following datasets:
 
+- ``object_pose/has_pose``: Boolean indicating whether the object was found at all.  If
+  `false`, `confidence` is expected to be zero and values of `position` and
+  `orientation` are meaningless.
 - ``object_pose/position``: The estimated x, y, z-position of the object w.r.t. the
   world frame.  Dimensions: ``(n_observations, 3)``.
 - ``object_pose/orientation``: The estimated orientation of the object w.r.t. the world

--- a/scripts/tricamera_log_to_hdf5.py
+++ b/scripts/tricamera_log_to_hdf5.py
@@ -104,6 +104,11 @@ def main() -> int:
         # Add the object information
         object_group = h5.create_group("object_pose")
         object_group.create_dataset(
+            "has_pose",
+            data=[obs.object_pose.confidence > 0 for obs in log_reader.data],
+            dtype=np.bool_,
+        )
+        object_group.create_dataset(
             "position",
             data=[obs.object_pose.position for obs in log_reader.data],
             dtype=np.double,


### PR DESCRIPTION
In principle it's possible to get this information from the confidence but it's probably better to have an explicit field for this (also to make new users aware of the possibility that position/orientation are random garbage in some cases).
