### PR TITLE
Use external TriCamera backend in the driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   frame in a HDF5 logfile.
 - Add executable `tricamera_log_to_hdf5` to convert existing log files from the native
   format to HDF5 (using same structure as `trifinger_cameras`).
+- Experimental: `TriCameraObjectTrackerDriver` can now alternatively use a `SensorData`
+  instance to fetch images instead of using an internal `TriCameraDriver` instance.
+  This can be used to have a pure camera backend at a higher rate and run the object
+  tracking at a lower rate.
 
 ### Removed
 - The `ProgramOptions` class has been moved to its own package

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,6 +320,7 @@ install(
     PROGRAMS
         demos/demo_cameras.py
         demos/demo_lightblue_segmenter.py
+        demos/demo_tricamera_separate_backend.py
         demos/run_on_logfile.py
 
     DESTINATION lib/${PROJECT_NAME}

--- a/demos/demo_cameras.py
+++ b/demos/demo_cameras.py
@@ -12,14 +12,12 @@ import numpy as np
 import signal_handler
 import trifinger_object_tracking.py_object_tracker as object_tracker
 import trifinger_object_tracking.py_tricamera_types as tricamera
-from trifinger_cameras import utils
+from trifinger_cameras import CAMERA_NAMES, utils
 
 
-camera_names = ["camera60", "camera180", "camera300"]
 calib_files = [
-    pathlib.Path("/etc/trifingerpro/camera60_cropped_and_downsampled.yml"),
-    pathlib.Path("/etc/trifingerpro/camera180_cropped_and_downsampled.yml"),
-    pathlib.Path("/etc/trifingerpro/camera300_cropped_and_downsampled.yml"),
+    pathlib.Path(f"/etc/trifingerpro/{camera}_cropped_and_downsampled.yml")
+    for camera in CAMERA_NAMES
 ]
 
 
@@ -55,7 +53,7 @@ def front_end_loop(
         )
 
         stacked_image = np.hstack(images)
-        cv2.imshow(" | ".join(camera_names), stacked_image)
+        cv2.imshow(" | ".join(CAMERA_NAMES), stacked_image)
 
         now = time.time()
         if (now - last_print) >= 1.0:

--- a/demos/demo_tricamera_separate_backend.py
+++ b/demos/demo_tricamera_separate_backend.py
@@ -23,34 +23,37 @@ def main() -> int:
         format="[%(asctime)s] [%(name)s | %(levelname)s] %(message)s",
     )
 
-    # create tricamera backend
     camera_data = tc.tricamera.SingleProcessData()
+    tracker_data = ot_tricamera.SingleProcessData()
+
+    logging.debug("create and start loggers")
+    camera_logger = tc.tricamera.Logger(camera_data, 1000)
+    tracker_logger = ot_tricamera.Logger(tracker_data, 1000)
+    camera_logger.start()
+    tracker_logger.start()
+
+    logging.debug("create tricamera backend")
     camera_driver = tc.tricamera.TriCameraDriver(*tc.CAMERA_NAMES)
     camera_backend = tc.tricamera.Backend(camera_driver, camera_data)
 
-    # create tricameraobjecttracking driver & backend
+    logging.debug("create tricameraobjecttracking driver & backend")
     model = object_tracker.get_model_by_name("cube_v2")
-    tracker_data = ot_tricamera.SingleProcessData()
     tracker_driver = ot_tricamera.TriCameraObjectTrackerDriver(
         camera_data, cube_model=model
     )
     tracker_backend = ot_tricamera.Backend(tracker_driver, tracker_data)
 
-    # create loggers for both
-    camera_logger = tc.tricamera.Logger(camera_data, buffer_size=1000)
-    tracker_logger = ot_tricamera.Logger(tracker_data, buffer_size=1000)
-
     # run until logger buffers are full and save to /tmp
-    camera_logger.start()
-    tracker_logger.start()
     while camera_logger.is_running() or tracker_logger.is_running():
         time.sleep(0.1)
 
+    logging.info("Finished logging.  Write data to /tmp.")
     camera_logger.stop_and_save("/tmp/camera_log.dat")
     tracker_logger.stop_and_save("/tmp/tracker_log.dat")
 
-    camera_backend.shutdown()
+    logging.info("Shutdown the backends")
     tracker_backend.shutdown()
+    camera_backend.shutdown()
 
     return 0
 

--- a/demos/demo_tricamera_separate_backend.py
+++ b/demos/demo_tricamera_separate_backend.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Example on how to connect the driver to an external TriCamera backend."""
+import argparse
+import contextlib
+import logging
+import time
+import sys
+
+import trifinger_cameras as tc
+import trifinger_object_tracking.py_object_tracker as object_tracker
+import trifinger_object_tracking.py_tricamera_types as ot_tricamera
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--verbose", "-v", action="store_true", help="Enable verbose output."
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="[%(asctime)s] [%(name)s | %(levelname)s] %(message)s",
+    )
+
+    # create tricamera backend
+    camera_data = tc.tricamera.SingleProcessData()
+    camera_driver = tc.tricamera.TriCameraDriver(*tc.CAMERA_NAMES)
+    camera_backend = tc.tricamera.Backend(camera_driver, camera_data)
+
+    # create tricameraobjecttracking driver & backend
+    model = object_tracker.get_model_by_name("cube_v2")
+    tracker_data = ot_tricamera.SingleProcessData()
+    tracker_driver = ot_tricamera.TriCameraObjectTrackerDriver(
+        camera_data, cube_model=model
+    )
+    tracker_backend = ot_tricamera.Backend(tracker_driver, tracker_data)
+
+    # create loggers for both
+    camera_logger = tc.tricamera.Logger(camera_data, buffer_size=1000)
+    tracker_logger = ot_tricamera.Logger(tracker_data, buffer_size=1000)
+
+    # run until logger buffers are full and save to /tmp
+    camera_logger.start()
+    tracker_logger.start()
+    while camera_logger.is_running() or tracker_logger.is_running():
+        time.sleep(0.1)
+
+    camera_logger.stop_and_save("/tmp/camera_log.dat")
+    tracker_logger.stop_and_save("/tmp/tracker_log.dat")
+
+    camera_backend.shutdown()
+    tracker_backend.shutdown()
+
+    return 0
+
+
+if __name__ == "__main__":
+    with contextlib.suppress(KeyboardInterrupt):
+        sys.exit(main())

--- a/doc/breathing_cat.toml
+++ b/doc/breathing_cat.toml
@@ -4,6 +4,7 @@ exclude_patterns = ["${PACKAGE_DIR}/include/optim/*"]
 [intersphinx.mapping]
 trifinger_docs = "https://open-dynamic-robot-initiative.github.io/trifinger_docs"
 trifinger_cameras = "https://open-dynamic-robot-initiative.github.io/trifinger_cameras"
+robot_interfaces = "https://open-dynamic-robot-initiative.github.io/robot_interfaces"
 
 [mainpage]
 title = "trifinger_object_tracking: Multi-camera pose estimation of coloured cuboids"

--- a/include/trifinger_object_tracking/tricamera_object_tracking_driver.hpp
+++ b/include/trifinger_object_tracking/tricamera_object_tracking_driver.hpp
@@ -7,6 +7,7 @@
 
 #include <chrono>
 #include <filesystem>
+#include <memory>
 
 #include <robot_interfaces/sensors/sensor_driver.hpp>
 #include <trifinger_cameras/camera_parameters.hpp>
@@ -100,7 +101,7 @@ public:
 
 private:
     bool downsample_images_ = true;
-    trifinger_cameras::TriCameraDriver camera_driver_;
+    std::unique_ptr<trifinger_cameras::TriCameraDriver> camera_driver_;
     trifinger_object_tracking::CubeDetector cube_detector_;
 
     ObjectPose previous_pose_;

--- a/include/trifinger_object_tracking/tricamera_object_tracking_driver.hpp
+++ b/include/trifinger_object_tracking/tricamera_object_tracking_driver.hpp
@@ -119,7 +119,7 @@ private:
 
     std::unique_ptr<trifinger_cameras::TriCameraDriver> camera_driver_;
     std::unique_ptr<TriCameraFrontend> camera_frontend_;
-    TriCameraFrontend::TimeIndex camera_frontend_last_timeindex_ = 0;
+    TriCameraFrontend::TimeIndex camera_frontend_next_timeindex_ = 0;
 
     ObjectPose previous_pose_;
 

--- a/include/trifinger_object_tracking/tricamera_object_tracking_driver.hpp
+++ b/include/trifinger_object_tracking/tricamera_object_tracking_driver.hpp
@@ -31,10 +31,6 @@ class TriCameraObjectTrackerDriver
                                             trifinger_cameras::TriCameraInfo>
 {
 public:
-    //! @brief Rate at which images are acquired.
-    static constexpr std::chrono::milliseconds rate =
-        std::chrono::milliseconds(100);
-
     static constexpr unsigned int N_CAMERAS = 3;
 
     /**

--- a/include/trifinger_object_tracking/tricamera_object_tracking_driver.hpp
+++ b/include/trifinger_object_tracking/tricamera_object_tracking_driver.hpp
@@ -120,6 +120,8 @@ private:
     std::unique_ptr<trifinger_cameras::TriCameraDriver> camera_driver_;
     std::unique_ptr<TriCameraFrontend> camera_frontend_;
     TriCameraFrontend::TimeIndex camera_frontend_next_timeindex_ = 0;
+    unsigned int camera_frontend_rate_multiplier_ =
+        1;  // FIXME: make configurable
 
     ObjectPose previous_pose_;
 

--- a/include/trifinger_object_tracking/tricamera_object_tracking_driver.hpp
+++ b/include/trifinger_object_tracking/tricamera_object_tracking_driver.hpp
@@ -123,6 +123,12 @@ private:
 
     ObjectPose previous_pose_;
 
+    TriCameraObjectTrackerDriver(
+        BaseCuboidModel::ConstPtr cube_model,
+        bool downsample_images,
+        std::unique_ptr<trifinger_cameras::TriCameraDriver> camera_driver,
+        std::unique_ptr<TriCameraFrontend> camera_frontend);
+
     trifinger_cameras::TriCameraObservation get_base_observation();
 };
 

--- a/include/trifinger_object_tracking/tricamera_object_tracking_driver.hpp
+++ b/include/trifinger_object_tracking/tricamera_object_tracking_driver.hpp
@@ -9,7 +9,9 @@
 #include <filesystem>
 #include <memory>
 
+#include <robot_interfaces/sensors/sensor_data.hpp>
 #include <robot_interfaces/sensors/sensor_driver.hpp>
+#include <robot_interfaces/sensors/sensor_frontend.hpp>
 #include <trifinger_cameras/camera_parameters.hpp>
 #include <trifinger_cameras/pylon_driver.hpp>
 #include <trifinger_cameras/settings.hpp>
@@ -69,6 +71,13 @@ public:
         bool downsample_images = true,
         trifinger_cameras::Settings settings = trifinger_cameras::Settings());
 
+    TriCameraObjectTrackerDriver(
+        robot_interfaces::SensorData<trifinger_cameras::TriCameraObservation,
+                                     trifinger_cameras::TriCameraInfo>::Ptr
+            camera_data,
+        BaseCuboidModel::ConstPtr cube_model,
+        bool downsample_images = true);
+
     /**
      * @brief Get the camera parameters.
      *
@@ -100,11 +109,20 @@ public:
     cv::Mat get_debug_image(bool fill_faces = false);
 
 private:
+    typedef robot_interfaces::SensorFrontend<
+        trifinger_cameras::TriCameraObservation,
+        trifinger_cameras::TriCameraInfo>
+        TriCameraFrontend;
+
     bool downsample_images_ = true;
-    std::unique_ptr<trifinger_cameras::TriCameraDriver> camera_driver_;
     trifinger_object_tracking::CubeDetector cube_detector_;
 
+    std::unique_ptr<trifinger_cameras::TriCameraDriver> camera_driver_;
+    std::unique_ptr<TriCameraFrontend> camera_frontend_;
+
     ObjectPose previous_pose_;
+
+    trifinger_cameras::TriCameraObservation get_base_observation() const;
 };
 
 }  // namespace trifinger_object_tracking

--- a/include/trifinger_object_tracking/tricamera_object_tracking_driver.hpp
+++ b/include/trifinger_object_tracking/tricamera_object_tracking_driver.hpp
@@ -23,24 +23,61 @@
 namespace trifinger_object_tracking
 {
 /**
- * @brief Driver to create three instances of the PylonDriver
- * and get observations from them.
+ * @brief Wrapper around ``trifinger_cameras::TriCameraDriver`` that adds object
+ *        tracking.
+ *
+ * @rst
+ * This class serves as a drop-in replacement (more or less) for
+ * :cpp:class:`trifinger_cameras::TriCameraDriver`.  It extends the latter with
+ * object tracking using the method provided by this package.  The resulting
+ * object pose is added to the camera observation.
+ *
+ * There are two methods for providing the camera images to the wrapper:
+ *
+ * 1. Pass three camera names or calibration files to the constructor.  In this
+ *    case an internal instance of
+ *    :cpp:class:`trifinger_cameras::TriCameraDriver` is created and used to get
+ *    the images.
+ * 2. Pass a :cpp:class:`robot_interfaces::SensorData` object that is connected
+ *    to a backend running the :cpp:class:`~trifinger_cameras::TriCameraDriver`.
+ *
+ * When method 1 is used, the driver will always run at the rate of the internal
+ * :cpp:class:`~trifinger_cameras::TriCameraDriver` instance (or as fast as a
+ * possible, if the pose estimation is slower than the camera rate). When method
+ * 2 is used, the driver will by default run at the rate at which the sensor
+ * backend provides observations but it can be stepped down by setting a
+ * multiplier to the environment variable
+ * ``TFOT_CAMERA_FRONTEND_RATE_MULTIPLIER``.  For example, set
+ * ``TFOT_CAMERA_FRONTEND_RATE_MULTIPLIER=5`` to run at 1/5 the rate of the
+ * observations provided through the given sensor data object.  This can be
+ * useful to maintain a constant rate of the object tracking driver in settings
+ * where the camera runs at a rate that is faster than the time needed for the
+ * pose estimation.
+ *
+ * While method 2 is more complex to set up, it allows for more flexibility as
+ * the object tracking can run at a lower rate than the camera.
+ *
+ * @endrst
  */
 class TriCameraObjectTrackerDriver
     : public robot_interfaces::SensorDriver<TriCameraObjectObservation,
                                             trifinger_cameras::TriCameraInfo>
 {
 public:
+    //! Number of cameras.
     static constexpr unsigned int N_CAMERAS = 3;
 
     /**
+     * @brief Construct with internal TriCameraDriver using device IDs.
+     *
      * @param device_id_1 device user id of first camera
      * @param device_id_2 likewise, the 2nd's
      * @param device_id_3 and the 3rd's
      * @param cube_model The model that is used for detecting the cube.
      * @param downsample_images If set to true (default), images are
      *     downsampled to half their original size for object tracking.
-     * @param settings Settings for the cameras.
+     * @param settings Settings for the cameras.  This is passed to the internal
+     *     TriCameraDriver.
      */
     TriCameraObjectTrackerDriver(
         const std::string& device_id_1,
@@ -51,13 +88,16 @@ public:
         trifinger_cameras::Settings settings = trifinger_cameras::Settings());
 
     /**
+     * @brief Construct with internal TriCameraDriver using calibration files.
+     *
      * @param camera_calibration_file_1 Calibration file of first camera
      * @param camera_calibration_file_2 likewise, the 2nd's
      * @param camera_calibration_file_3 and the 3rd's
      * @param cube_model The model that is used for detecting the cube.
      * @param downsample_images If set to true (default), images are
      *     downsampled to half their original size for object tracking.
-     * @param settings Settings for the cameras.
+     * @param settings Settings for the cameras.  This is passed to the internal
+     *     TriCameraDriver.
      */
     TriCameraObjectTrackerDriver(
         const std::filesystem::path& camera_calibration_file_1,
@@ -67,6 +107,18 @@ public:
         bool downsample_images = true,
         trifinger_cameras::Settings settings = trifinger_cameras::Settings());
 
+    /**
+     * @brief Construct with external camera data.
+     *
+     * Expects that a separate SensorBackend is running in parallel, which
+     * provides TriCameraObservations to the given SensorData object.
+     *
+     * @param camera_data The sensor data object that provides the camera
+     * images.
+     * @param cube_model The model that is used for detecting the cube.
+     * @param downsample_images If set to true (default), images are
+     *     downsampled to half their original size for object tracking.
+     */
     TriCameraObjectTrackerDriver(
         robot_interfaces::SensorData<trifinger_cameras::TriCameraObservation,
                                      trifinger_cameras::TriCameraInfo>::Ptr

--- a/include/trifinger_object_tracking/tricamera_object_tracking_driver.hpp
+++ b/include/trifinger_object_tracking/tricamera_object_tracking_driver.hpp
@@ -119,6 +119,7 @@ private:
 
     std::unique_ptr<trifinger_cameras::TriCameraDriver> camera_driver_;
     std::unique_ptr<TriCameraFrontend> camera_frontend_;
+    TriCameraFrontend::TimeIndex camera_frontend_last_timeindex_ = 0;
 
     ObjectPose previous_pose_;
 

--- a/include/trifinger_object_tracking/tricamera_object_tracking_driver.hpp
+++ b/include/trifinger_object_tracking/tricamera_object_tracking_driver.hpp
@@ -123,7 +123,7 @@ private:
 
     ObjectPose previous_pose_;
 
-    trifinger_cameras::TriCameraObservation get_base_observation() const;
+    trifinger_cameras::TriCameraObservation get_base_observation();
 };
 
 }  // namespace trifinger_object_tracking

--- a/include/trifinger_object_tracking/tricamera_object_tracking_driver.hpp
+++ b/include/trifinger_object_tracking/tricamera_object_tracking_driver.hpp
@@ -168,8 +168,7 @@ private:
     std::unique_ptr<trifinger_cameras::TriCameraDriver> camera_driver_;
     std::unique_ptr<TriCameraFrontend> camera_frontend_;
     TriCameraFrontend::TimeIndex camera_frontend_next_timeindex_ = 0;
-    unsigned int camera_frontend_rate_multiplier_ =
-        1;  // FIXME: make configurable
+    unsigned int camera_frontend_rate_multiplier_ = 1;
 
     ObjectPose previous_pose_;
 

--- a/src/tricamera_object_tracking_driver.cpp
+++ b/src/tricamera_object_tracking_driver.cpp
@@ -97,24 +97,22 @@ TriCameraObjectTrackerDriver::get_base_observation()
     {
         constexpr int camera_rate_multiplier = 1;  // FIXME: make configurable
 
-        TriCameraFrontend::TimeIndex t_next =
-            camera_frontend_last_timeindex_ + camera_rate_multiplier;
-
         // Use the latest time index if falling behind.  This results in
         // inconsistent rate and thus should normally be avoided by setting the
         // desired rate slow enough.
         auto t_current = camera_frontend_->get_current_timeindex();
-        if (t_next < t_current)
+        if (camera_frontend_next_timeindex_ < t_current)
         {
             fmt::print(
                 "WARNING: Falling behind {} steps in "
                 "TriCameraObjectTrackerDriver.\n",
-                t_current - t_next);
-            t_next = t_current;
+                t_current - camera_frontend_next_timeindex_);
+            camera_frontend_next_timeindex_ = t_current;
         }
 
-        auto obs = camera_frontend_->get_observation(t_next);
-        camera_frontend_last_timeindex_ = t_next;
+        auto obs =
+            camera_frontend_->get_observation(camera_frontend_next_timeindex_);
+        camera_frontend_next_timeindex_ += camera_rate_multiplier;
 
         return obs;
     }

--- a/src/tricamera_object_tracking_driver.cpp
+++ b/src/tricamera_object_tracking_driver.cpp
@@ -28,7 +28,8 @@ TriCameraObjectTrackerDriver::TriCameraObjectTrackerDriver(
       camera_driver_(std::move(camera_driver)),
       camera_frontend_(std::move(camera_frontend))
 {
-    if (const char* strval = std::getenv("TFOT_CAMERA_FRONTEND_RATE_MULTIPLIER"))
+    if (const char* strval =
+            std::getenv("TFOT_CAMERA_FRONTEND_RATE_MULTIPLIER"))
     {
         camera_frontend_rate_multiplier_ = std::stoi(strval);
     }

--- a/src/tricamera_object_tracking_driver.cpp
+++ b/src/tricamera_object_tracking_driver.cpp
@@ -93,7 +93,16 @@ TriCameraObjectTrackerDriver::get_base_observation() const
     }
     else
     {
-        return camera_frontend_->get_latest_observation();
+        // If there is a new camera observation since the last call, use the latest.
+        // Otherwise wait for the next one (do not use the same twice).
+        auto t = camera_frontend_->get_current_timeindex();
+        if (t == camera_frontend_last_timeindex_)
+        {
+            t++;
+        }
+        camera_frontend_last_timeindex_ = t;
+
+        return camera_frontend_->get_observation(t);
     }
 }
 

--- a/src/tricamera_object_tracking_driver.cpp
+++ b/src/tricamera_object_tracking_driver.cpp
@@ -31,6 +31,10 @@ TriCameraObjectTrackerDriver::TriCameraObjectTrackerDriver(
       camera_driver_(std::move(camera_driver)),
       camera_frontend_(std::move(camera_frontend))
 {
+    if (const char* strval = std::getenv("TFOT_CAMERA_FRONTEND_RATE_MULTIPLIER"))
+    {
+        camera_frontend_rate_multiplier_ = std::stoi(strval);
+    }
 }
 
 TriCameraObjectTrackerDriver::TriCameraObjectTrackerDriver(
@@ -109,8 +113,6 @@ TriCameraObjectTrackerDriver::get_base_observation()
     }
     else
     {
-        constexpr int camera_rate_multiplier = 1;  // FIXME: make configurable
-
         // Use the latest time index if falling behind.  This results in
         // inconsistent rate and thus should normally be avoided by setting the
         // desired rate slow enough.
@@ -126,7 +128,7 @@ TriCameraObjectTrackerDriver::get_base_observation()
 
         auto obs =
             camera_frontend_->get_observation(camera_frontend_next_timeindex_);
-        camera_frontend_next_timeindex_ += camera_rate_multiplier;
+        camera_frontend_next_timeindex_ += camera_frontend_rate_multiplier_;
 
         return obs;
     }

--- a/src/tricamera_object_tracking_driver.cpp
+++ b/src/tricamera_object_tracking_driver.cpp
@@ -20,6 +20,20 @@ namespace trifinger_object_tracking
 constexpr std::chrono::milliseconds TriCameraObjectTrackerDriver::rate;
 
 TriCameraObjectTrackerDriver::TriCameraObjectTrackerDriver(
+    BaseCuboidModel::ConstPtr cube_model,
+    bool downsample_images,
+    std::unique_ptr<trifinger_cameras::TriCameraDriver> camera_driver,
+    std::unique_ptr<TriCameraFrontend> camera_frontend)
+    : downsample_images_(downsample_images),
+      cube_detector_(
+          trifinger_object_tracking::create_trifingerpro_cube_detector(
+              cube_model, downsample_images)),
+      camera_driver_(std::move(camera_driver)),
+      camera_frontend_(std::move(camera_frontend))
+{
+}
+
+TriCameraObjectTrackerDriver::TriCameraObjectTrackerDriver(
     const std::string& device_id_1,
     const std::string& device_id_2,
     const std::string& device_id_3,
@@ -27,16 +41,16 @@ TriCameraObjectTrackerDriver::TriCameraObjectTrackerDriver(
     bool downsample_images,
     trifinger_cameras::Settings settings)
 
-    : downsample_images_(downsample_images),
-      cube_detector_(
-          trifinger_object_tracking::create_trifingerpro_cube_detector(
-              cube_model, downsample_images)),
-      camera_driver_(std::make_unique<trifinger_cameras::TriCameraDriver>(
-          device_id_1,
-          device_id_2,
-          device_id_3,
-          false,  // downsample_images not supported anymore
-          settings))
+    : TriCameraObjectTrackerDriver(
+          cube_model,
+          downsample_images,
+          std::make_unique<trifinger_cameras::TriCameraDriver>(
+              device_id_1,
+              device_id_2,
+              device_id_3,
+              false,  // downsample_images not supported anymore
+              settings),
+          nullptr)
 {
 }
 
@@ -47,16 +61,16 @@ TriCameraObjectTrackerDriver::TriCameraObjectTrackerDriver(
     BaseCuboidModel::ConstPtr cube_model,
     bool downsample_images,
     trifinger_cameras::Settings settings)
-    : downsample_images_(downsample_images),
-      cube_detector_(
-          trifinger_object_tracking::create_trifingerpro_cube_detector(
-              cube_model, downsample_images)),
-      camera_driver_(std::make_unique<trifinger_cameras::TriCameraDriver>(
-          camera_calibration_file_1,
-          camera_calibration_file_2,
-          camera_calibration_file_3,
-          false,  // downsample_images not supported anymore
-          settings))
+    : TriCameraObjectTrackerDriver(
+          cube_model,
+          downsample_images,
+          std::make_unique<trifinger_cameras::TriCameraDriver>(
+              camera_calibration_file_1,
+              camera_calibration_file_2,
+              camera_calibration_file_3,
+              false,  // downsample_images not supported anymore
+              settings),
+          nullptr)
 {
 }
 
@@ -66,11 +80,11 @@ TriCameraObjectTrackerDriver::TriCameraObjectTrackerDriver(
         camera_data,
     BaseCuboidModel::ConstPtr cube_model,
     bool downsample_images)
-    : downsample_images_(downsample_images),
-      cube_detector_(
-          trifinger_object_tracking::create_trifingerpro_cube_detector(
-              cube_model, downsample_images)),
-      camera_frontend_(std::make_unique<TriCameraFrontend>(camera_data))
+    : TriCameraObjectTrackerDriver(
+          cube_model,
+          downsample_images,
+          nullptr,
+          std::make_unique<TriCameraFrontend>(camera_data))
 {
 }
 

--- a/src/tricamera_object_tracking_driver.cpp
+++ b/src/tricamera_object_tracking_driver.cpp
@@ -25,11 +25,12 @@ TriCameraObjectTrackerDriver::TriCameraObjectTrackerDriver(
     bool downsample_images,
     trifinger_cameras::Settings settings)
     : downsample_images_(downsample_images),
-      camera_driver_(device_id_1,
-                     device_id_2,
-                     device_id_3,
-                     false,  // downsample_images not supported anymore
-                     settings),
+      camera_driver_(std::make_unique<trifinger_cameras::TriCameraDriver>(
+          device_id_1,
+          device_id_2,
+          device_id_3,
+          false,  // downsample_images not supported anymore
+          settings)),
       cube_detector_(
           trifinger_object_tracking::create_trifingerpro_cube_detector(
               cube_model, downsample_images))
@@ -44,11 +45,12 @@ TriCameraObjectTrackerDriver::TriCameraObjectTrackerDriver(
     bool downsample_images,
     trifinger_cameras::Settings settings)
     : downsample_images_(downsample_images),
-      camera_driver_(camera_calibration_file_1,
-                     camera_calibration_file_2,
-                     camera_calibration_file_3,
-                     false,  // downsample_images not supported anymore
-                     settings),
+      camera_driver_(std::make_unique<trifinger_cameras::TriCameraDriver>(
+          camera_calibration_file_1,
+          camera_calibration_file_2,
+          camera_calibration_file_3,
+          false,  // downsample_images not supported anymore
+          settings)),
       cube_detector_(
           trifinger_object_tracking::create_trifingerpro_cube_detector(
               cube_model, downsample_images))
@@ -57,14 +59,14 @@ TriCameraObjectTrackerDriver::TriCameraObjectTrackerDriver(
 
 trifinger_cameras::TriCameraInfo TriCameraObjectTrackerDriver::get_sensor_info()
 {
-    return camera_driver_.get_sensor_info();
+    return camera_driver_->get_sensor_info();
 }
 
 TriCameraObjectObservation TriCameraObjectTrackerDriver::get_observation()
 {
     std::array<cv::Mat, N_CAMERAS> images_bgr;
 
-    TriCameraObjectObservation observation = camera_driver_.get_observation();
+    TriCameraObjectObservation observation = camera_driver_->get_observation();
 
     for (size_t i = 0; i < N_CAMERAS; i++)
     {

--- a/src/tricamera_object_tracking_driver.cpp
+++ b/src/tricamera_object_tracking_driver.cpp
@@ -16,9 +16,6 @@
 
 namespace trifinger_object_tracking
 {
-// this needs to be declared here...
-constexpr std::chrono::milliseconds TriCameraObjectTrackerDriver::rate;
-
 TriCameraObjectTrackerDriver::TriCameraObjectTrackerDriver(
     BaseCuboidModel::ConstPtr cube_model,
     bool downsample_images,

--- a/srcpy/py_tricamera_types.cpp
+++ b/srcpy/py_tricamera_types.cpp
@@ -83,6 +83,14 @@ PYBIND11_MODULE(py_tricamera_types, m)
              pybind11::arg("camera_calibration_file_3"),
              pybind11::arg("cube_model"),
              pybind11::arg("downsample_images") = true)
+        .def(pybind11::init<robot_interfaces::SensorData<
+                                trifinger_cameras::TriCameraObservation,
+                                trifinger_cameras::TriCameraInfo>::Ptr,
+                            BaseCuboidModel::ConstPtr,
+                            bool>(),
+             pybind11::arg("camera_data"),
+             pybind11::arg("cube_model"),
+             pybind11::arg("downsample_images") = true)
         .def("get_observation",
              &TriCameraObjectTrackerDriver::get_observation,
              "Get the latest observation from the three cameras.")


### PR DESCRIPTION
## Description

As an alternative to the already existing method of using an internal instance of `trifinger_cameras::TriCameraDriver`, the `TriCameraWithObjectDriver` can now also use a `SensorData` handle to fetch images from a separately running TriCamera backend.

When using this method, the driver will by default run at the rate at which the sensor backend provides observations but it can be stepped down by setting a multiplier to the environment variable ``TFOT_CAMERA_FRONTEND_RATE_MULTIPLIER``.  For example, set ``TFOT_CAMERA_FRONTEND_RATE_MULTIPLIER=5`` to run at 1/5 the rate of the observations provided through the given sensor data object.  This can be useful to maintain a constant rate of the object tracking driver in settings where the camera runs at a rate that is faster than the time needed for the pose estimation.

While this method is more complex to set up, it allows for more flexibility as the object tracking can run at a lower rate than the camera.

I still consider the current implementation as experimental, so there might still be some quirks and the behaviour may change in the future.

## How I Tested

On the robot, using separate loggers for the pure camera and the camera-with-object data.